### PR TITLE
Added edit and delete transaction

### DIFF
--- a/MyMoney.Core/Interfaces/Entities/IBudget.cs
+++ b/MyMoney.Core/Interfaces/Entities/IBudget.cs
@@ -12,6 +12,7 @@ namespace MyMoney.Core.Interfaces.Entities
 
         IUser User { get; set; }
         IQueryable<ITransaction> Transactions { get; }
-        void AddTransaction(ITransaction transaction);
+        void AddTransaction(IRelationRepository _relationRepository, ITransaction transaction);
+        void RemoveTransaction(IRelationRepository relationRepository, ITransaction transaction);
     }
 }

--- a/MyMoney.Core/Interfaces/Entities/IRelationEntity.cs
+++ b/MyMoney.Core/Interfaces/Entities/IRelationEntity.cs
@@ -1,0 +1,6 @@
+﻿namespace MyMoney.Core.Interfaces.Entities
+{
+    public interface IRelationEntity
+    {
+    }
+}

--- a/MyMoney.Core/Interfaces/IRelationRepository.cs
+++ b/MyMoney.Core/Interfaces/IRelationRepository.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using MyMoney.Core.Interfaces.Entities;
+
+namespace MyMoney.Core.Interfaces
+{
+    public interface IRelationRepository : IDisposable
+    {
+        T Add<T>(T newItem) where T : class, IRelationEntity;
+        bool Delete<T>(T item) where T : class, IRelationEntity;
+    }
+}

--- a/MyMoney.Core/Interfaces/Service/ITransactionService.cs
+++ b/MyMoney.Core/Interfaces/Service/ITransactionService.cs
@@ -6,7 +6,7 @@ namespace MyMoney.Core.Interfaces.Service
     public interface ITransactionService
     {
         ITransaction Add(DateTime date, string description, decimal amount, long[] budgetIds);
-        bool Update(long transactionId, DateTime date, string description, decimal amount);
+        bool Update(long transactionId, DateTime date, string description, decimal amount, long[] budgetIds);
         bool Delete(long transactionId);
     }
 }

--- a/MyMoney.Core/Services/TransactionService.cs
+++ b/MyMoney.Core/Services/TransactionService.cs
@@ -10,12 +10,14 @@ namespace MyMoney.Core.Services
     public sealed class TransactionService : ITransactionService
     {
         private readonly IRepository _repository;
+        private readonly IRelationRepository _relationRepository;
         private readonly IEntityFactory _entityFactory;
         private readonly ICurrentUserProvider _currentUserProvider;
 
-        public TransactionService(IRepository repository, IEntityFactory entityFactory, ICurrentUserProvider currentUserProvider)
+        public TransactionService(IRepository repository, IRelationRepository relationRepository, IEntityFactory entityFactory, ICurrentUserProvider currentUserProvider)
         {
             _repository = repository;
+            _relationRepository = relationRepository;
             _entityFactory = entityFactory;
             _currentUserProvider = currentUserProvider;
         }
@@ -45,28 +47,45 @@ namespace MyMoney.Core.Services
 
             foreach (var budget in budgets)
             {
-                budget.AddTransaction(addedTransaction);
+                budget.AddTransaction(_relationRepository, addedTransaction);
             }
 
             return _repository.Update(addedTransaction) ? addedTransaction : null;
         }
 
-        public bool Update(long transactionId, DateTime date, string description, decimal amount)
+        public bool Update(long transactionId, DateTime date, string description, decimal amount, long[] budgetIds)
         {
             if (string.IsNullOrWhiteSpace(description))
                 return false;
 
             var transaction = _repository.FindById<ITransaction>(transactionId);
-            var userId = _currentUserProvider.CurrentUserId;
+            var user = _currentUserProvider.CurrentUser;
 
-            if (transaction == null || transaction.UserId != userId)
+            if (transaction == null || transaction.UserId != user.Id)
                 return false;
 
             transaction.Amount = amount;
             transaction.Date = date;
             transaction.Description = description;
 
-            return _repository.Update(transaction);
+            if (!_repository.Update(transaction))
+            {
+                return false;
+            }
+
+            foreach (var budget in transaction.Budgets.ToList())
+            {
+                budget.RemoveTransaction(_relationRepository, transaction);
+            }
+
+            var budgets = user.Budgets.Where(b => budgetIds.Contains(b.Id)).ToList();
+
+            foreach (var budget in budgets)
+            {
+                budget.AddTransaction(_relationRepository, transaction);
+            }
+
+            return true;
         }
 
         public bool Delete(long transactionId)

--- a/MyMoney.Infrastructure/Entities/Budget.cs
+++ b/MyMoney.Infrastructure/Entities/Budget.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
+using MyMoney.Core.Interfaces;
 using MyMoney.Core.Interfaces.Entities;
 
 namespace MyMoney.Infrastructure.Entities
@@ -29,11 +30,21 @@ namespace MyMoney.Infrastructure.Entities
         public IQueryable<ITransaction> Transactions => TransactionsProxy.Select(tb => tb.Transaction).Cast<ITransaction>().AsQueryable();
         public virtual ICollection<TransactionBudget> TransactionsProxy { get; set; } = new List<TransactionBudget>();
 
-        public void AddTransaction(ITransaction transaction)
+        public void AddTransaction(IRelationRepository relationRepository, ITransaction transaction)
         {
-            if(transaction is Transaction t)
+            if (transaction is Transaction t)
             {
-                TransactionsProxy.Add(new TransactionBudget(t, this));
+                relationRepository.Add(new TransactionBudget(t, this));
+            }
+        }
+
+        public void RemoveTransaction(IRelationRepository relationRepository, ITransaction transaction)
+        {
+            var transactionBudget = TransactionsProxy.FirstOrDefault(t => t.TransactionId == transaction.Id);
+
+            if (transactionBudget != null)
+            {
+                relationRepository.Delete(transactionBudget);
             }
         }
 

--- a/MyMoney.Infrastructure/Entities/TransactionBudget.cs
+++ b/MyMoney.Infrastructure/Entities/TransactionBudget.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using MyMoney.Core.Interfaces.Entities;
 using System.ComponentModel.DataAnnotations;
 
 namespace MyMoney.Infrastructure.Entities
 {
-    public class TransactionBudget
+    public class TransactionBudget : IRelationEntity
     {
         [Required]
         public long TransactionId { get; set; }

--- a/MyMoney.Infrastructure/RelationRepository.cs
+++ b/MyMoney.Infrastructure/RelationRepository.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using MyMoney.Core.Interfaces;
+using MyMoney.Core.Interfaces.Entities;
+using MyMoney.Infrastructure.EntityFramework;
+
+namespace MyMoney.Infrastructure
+{
+    public sealed class RelationRepository : IRelationRepository
+    {
+        private readonly DatabaseContext _model;
+
+        public RelationRepository(DatabaseContext model)
+        {
+            _model = model;
+        }
+
+        public void Dispose()
+        {
+            _model.Dispose();
+        }
+
+        public T Add<T>(T newItem) where T : class, IRelationEntity
+        {
+            if (newItem == null)
+                return null;
+
+            try
+            {
+                _model.Add(newItem);
+                _model.SaveChanges();
+
+                return newItem;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return null;
+            }
+
+        }
+
+        public bool Delete<T>(T item) where T : class, IRelationEntity
+        {
+            if (item == null)
+                return false;
+
+            try
+            {
+                _model.Remove(item);
+                _model.SaveChanges();
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return false;
+            }
+        }
+    }
+}

--- a/MyMoney.Web/ClientApp/src/app/app.module.ts
+++ b/MyMoney.Web/ClientApp/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { AddTransactionsComponent } from './transactions/add/add.transactions.co
 import { TransactionsComponent } from './transactions/transactions.component';
 import { BudgetsComponent } from './budgets/budgets.component';
 import { AddBudgetsComponent } from './budgets/add/add.budgets.component';
+import { EditTransactionsComponent } from './transactions/edit/edit.transactions.component';
 
 @NgModule({
   declarations: [
@@ -21,6 +22,7 @@ import { AddBudgetsComponent } from './budgets/add/add.budgets.component';
     LoginComponent,
     RegisterComponent,
     AddTransactionsComponent,
+    EditTransactionsComponent,
     TransactionsComponent,
     BudgetsComponent,
     AddBudgetsComponent
@@ -36,6 +38,7 @@ import { AddBudgetsComponent } from './budgets/add/add.budgets.component';
       { path: 'register', component: RegisterComponent },
       { path: 'transactions', component: TransactionsComponent, pathMatch: 'full' },
       { path: 'transactions/add', component: AddTransactionsComponent, pathMatch: 'full' },
+      { path: 'transactions/edit/:id', component: EditTransactionsComponent, pathMatch: 'full' },
       { path: 'budgets', component: BudgetsComponent, pathMatch: 'full' },
       { path: 'budgets/add', component: AddBudgetsComponent, pathMatch: 'full' },
       { path: '', component: HomeComponent, pathMatch: 'full' },

--- a/MyMoney.Web/ClientApp/src/app/models/delete.response.ts
+++ b/MyMoney.Web/ClientApp/src/app/models/delete.response.ts
@@ -1,0 +1,3 @@
+export interface DeleteResponse {
+  success: boolean;
+}

--- a/MyMoney.Web/ClientApp/src/app/transactions/edit/edit.transactions.component.html
+++ b/MyMoney.Web/ClientApp/src/app/transactions/edit/edit.transactions.component.html
@@ -1,0 +1,56 @@
+<h2>Edit transaction {{id}} </h2>
+<div class="row">
+  <div class="col-6">
+    <form [formGroup]="editTransactionForm" (ngSubmit)="onSubmit()">
+      <div class="form-group">
+        <label for="date">Date</label>
+        <input type="date" formControlName="date" class="form-control" [ngClass]="{ 'is-invalid': submitted && f.date.errors }" (change)="onDateChange($event)"/>
+        <div *ngIf="submitted && f.date.errors" class="invalid-feedback">
+          <div *ngIf="f.date.errors.required">Date is required</div>
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="description">Description</label>
+        <input type="text" formControlName="description" class="form-control" [ngClass]="{ 'is-invalid': submitted && f.description.errors }" />
+        <div *ngIf="submitted && f.description.errors" class="invalid-feedback">
+          <div *ngIf="f.description.errors.required">description is required</div>
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="amount">Amount</label>
+        <input type="number" formControlName="amount" class="form-control" [ngClass]="{ 'is-invalid': submitted && f.amount.errors }" />
+        <div *ngIf="submitted && f.amount.errors" class="invalid-feedback">
+          <div *ngIf="f.amount.errors.required">amount is required</div>
+        </div>
+      </div>
+      <div class="form-group">
+        <button [disabled]="loading" class="btn btn-primary">
+          <span *ngIf="loading" class="spinner-border spinner-border-sm mr-1"></span>
+          Update
+        </button>
+      </div>
+    </form>
+  </div>
+  <div class="col-6">
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col"></th>
+          <th scope="col">Name</th>
+          <th scope="col">Amount</th>
+          <th scope="col">Remaining</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let budget of budgets; let i = index">
+          <td>
+            <input type="checkbox" [value]="budget.id" [checked]="selectedBudgets.has(budget.id)" (change)="onCheckboxChange($event, budget.id)" />
+          </td>
+          <td>{{budget.name}}</td>
+          <td>{{budget.amount}}</td>
+          <td>{{budget.remaining}}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/MyMoney.Web/ClientApp/src/app/transactions/edit/edit.transactions.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/transactions/edit/edit.transactions.component.ts
@@ -1,0 +1,155 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router, ActivatedRoute } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+
+import { AuthenticationService } from '../../authentication.service';
+import { TransactionModel } from '../../models/transaction.model';
+import { BudgetViewModel } from '../../models/budget.view.model';
+import { BudgetListResponse } from '../../models/budget.list.response';
+
+@Component({
+  selector: 'edit-transactions-component',
+  templateUrl: './edit.transactions.component.html'
+})
+export class EditTransactionsComponent implements OnInit {
+
+  editTransactionForm: FormGroup;
+  selectedBudgets: Set<Number> = new Set();
+  budgets: Array<BudgetViewModel> = [];
+  id: Number;
+  loading = false;
+  submitted = false;
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private authenticationService: AuthenticationService,
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private http: HttpClient
+  ) {
+
+    if (!this.authenticationService.isLoggedIn) {
+      this.router.navigate(['/login']);
+    }
+  }
+
+  ngOnInit() {
+
+    this.activatedRoute.params.subscribe(params => {
+      var idStr = params['id'];
+
+      if (!idStr) {
+        this.router.navigate(['/transactions']);
+      }
+
+      this.id = Number.parseInt(idStr);
+
+      this.http
+        .post<TransactionModel>(`/Transaction/Find`, { id: this.id })
+        .subscribe(response => {
+
+          response.budgetIds.forEach(bid => this.selectedBudgets.add(bid));
+
+          this.editTransactionForm = this.formBuilder.group({
+            date: [this.toInputDateString(response.date), Validators.required],
+            description: [response.description, Validators.required],
+            amount: [response.amount, Validators.required]
+          });
+
+          this.fetchbudgets();
+        },
+          error => {
+            this.router.navigate(['/transactions']);
+          });
+    });
+
+
+  }
+
+  get f() { return this.editTransactionForm.controls; }
+
+  onCheckboxChange(e, id) {
+    if (e.target.checked) {
+      this.selectedBudgets.add(id);
+    } else {
+      this.selectedBudgets.delete(id);
+    }
+  }
+
+  onDateChange(e) {
+
+    this.selectedBudgets.clear();
+
+    this.fetchbudgets();
+  }
+
+  toInputDateString(text): String {
+    var date = new Date(text);
+
+    var month = date.getMonth() + 1;
+
+    var monthStr = month < 10 ? "0" + month : month;
+
+    var day = date.getDate();
+
+    var dayStr = day < 10 ? "0" + day : day;
+
+    return date.getFullYear() + "-" + dayStr + "-" + monthStr;
+  }
+
+  fetchbudgets(): void {
+
+    this.loading = false;
+
+    var date = new Date(this.f.date.value);
+
+    var month = date.getMonth() + 1;
+
+    var monthStr = month < 10 ? "0" + month : month;
+
+    var monthId = "" + date.getFullYear() + monthStr;
+
+    this.http
+      .post<BudgetListResponse>(`/Budget/List`, { monthId })
+      .subscribe(response => {
+
+        this.budgets = response.budgets.map(t => new BudgetViewModel(t));
+        this.loading = false;
+      },
+        error => {
+          // TODO: Show error
+          this.loading = false;
+        });
+  }
+
+  onSubmit() {
+    this.submitted = true;
+
+    // stop here if form is invalid
+    if (this.editTransactionForm.invalid) {
+      return;
+    }
+
+    this.loading = true;
+
+    // Login here
+    var date = this.f.date.value;
+    var description = this.f.description.value;
+    var amount = this.f.amount.value;
+
+    var transaction: TransactionModel = { date, description, amount, id: this.id, budgetIds: Array.from(this.selectedBudgets) };
+
+    this.http
+      .post<TransactionModel>(`/Transaction/Update`, transaction)
+      .subscribe(response => {
+        if (response.id != 0) {
+          this.router.navigate(["/transactions"]);
+        }
+      },
+        error => {
+          // Show error
+          this.loading = false;
+        });
+  }
+}

--- a/MyMoney.Web/ClientApp/src/app/transactions/transactions.component.html
+++ b/MyMoney.Web/ClientApp/src/app/transactions/transactions.component.html
@@ -34,6 +34,7 @@
         <th scope="col">Date</th>
         <th scope="col">Description</th>
         <th scope="col">Amount</th>
+        <th scope="col"></th>
       </tr>
     </thead>
     <tbody>
@@ -41,6 +42,7 @@
         <td>{{transaction.date}}</td>
         <td>{{transaction.description}}</td>
         <td>{{transaction.amount}}</td>
+        <td><button class="btn btn-danger" (click)="delete(transaction.id)">✕</button></td>
       </tr>
     </tbody>
   </table>

--- a/MyMoney.Web/ClientApp/src/app/transactions/transactions.component.html
+++ b/MyMoney.Web/ClientApp/src/app/transactions/transactions.component.html
@@ -25,6 +25,11 @@
         Update
       </button>
     </div>
+    <div class="input-group mb-3">
+      <a class="btn btn-success" href="/transactions/add">
+        Add
+      </a>
+    </div>
   </div>
 </form>
 <div class="container-fluid">
@@ -42,7 +47,10 @@
         <td>{{transaction.date}}</td>
         <td>{{transaction.description}}</td>
         <td>{{transaction.amount}}</td>
-        <td><button class="btn btn-danger" (click)="delete(transaction.id)">✕</button></td>
+        <td>
+          <a class="btn btn-primary" href="transactions/edit/{{transaction.id}}">🖉</a>
+          <button class="btn btn-danger" (click)="delete(transaction.id)">✕</button>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/MyMoney.Web/ClientApp/src/app/transactions/transactions.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/transactions/transactions.component.ts
@@ -8,6 +8,7 @@ import { TransactionModel } from '../models/transaction.model';
 import { DateRangeModel } from '../models/date.range.model';
 import { TransactionListResponse } from '../models/transaction.list.response';
 import { TransactionViewModel } from '../models/transaction.view.model';
+import { DeleteResponse } from '../models/delete.response';
 
 @Component({
   selector: 'transactions-component',
@@ -77,6 +78,26 @@ export class TransactionsComponent implements OnInit {
   }
 
   get f() { return this.dateRangeForm.controls; }
+
+  delete(id: Number) {
+
+    this.loading = true;
+
+    this.http
+      .post<DeleteResponse>(`/Transaction/Delete`, { id })
+      .subscribe(response => {
+
+        if (response.success) {
+          this.transactions = this.transactions.filter(v => v.id != id);
+        }
+        
+        this.loading = false;
+      },
+        error => {
+          // TODO: Show error
+          this.loading = false;
+        });
+  }
 
   onSubmit() {
     this.submitted = true;

--- a/MyMoney.Web/Controllers/TransactionController.cs
+++ b/MyMoney.Web/Controllers/TransactionController.cs
@@ -28,6 +28,31 @@ namespace MyMoney.Web.Controllers
             _transactionService = transactionService;
         }
 
+        [HttpPost(nameof(Find))]
+        public IActionResult Find([FromBody] FindRequest findParameters)
+        {
+            try
+            {
+                if (findParameters == null || !ModelState.IsValid)
+                {
+                    return BadRequest("Invalid State");
+                }
+
+                var transaction = _currentUserProvider.CurrentUser.Transactions.FirstOrDefault(t => t.Id == findParameters.Id);
+
+                if(transaction != null)
+                {
+                    return Ok(new TransactionModel(transaction));
+                }
+
+                return NotFound("Transaction does not exist");
+            }
+            catch (Exception)
+            {
+                return BadRequest("Error while creating");
+            }
+        }
+
         [HttpPost(nameof(List))]
         public IActionResult List([FromBody] DateRangeModel listParameters)
         {
@@ -61,7 +86,7 @@ namespace MyMoney.Web.Controllers
                     return BadRequest("Invalid State");
                 }
 
-                var success = _transactionService.Update(model.Id, DateTime.Parse(model.Date), model.Description, model.Amount);
+                var success = _transactionService.Update(model.Id, DateTime.Parse(model.Date), model.Description, model.Amount, model.BudgetIds);
 
                 return Ok(new UpdateResponse
                 {

--- a/MyMoney.Web/Models/Request/DeleteRequest.cs
+++ b/MyMoney.Web/Models/Request/DeleteRequest.cs
@@ -3,10 +3,5 @@
     public class DeleteRequest
     {
         public long Id { get; set; }
-
-        public DeleteRequest(long id)
-        {
-            Id = id;
-        }
     }
 }

--- a/MyMoney.Web/Models/Request/FindRequest.cs
+++ b/MyMoney.Web/Models/Request/FindRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace MyMoney.Web.Models.Request
+{
+    public class FindRequest
+    {
+        public long Id { get; set; }
+    }
+}

--- a/MyMoney.Web/MyMoney.Web.csproj
+++ b/MyMoney.Web/MyMoney.Web.csproj
@@ -41,12 +41,14 @@
     <None Remove="ClientApp\src\app\models\budget.list.response.ts" />
     <None Remove="ClientApp\src\app\models\budget.model.ts" />
     <None Remove="ClientApp\src\app\models\budget.view.model.ts" />
+    <None Remove="ClientApp\src\app\models\delete.response.ts" />
     <None Remove="ClientApp\src\app\models\login.response.ts" />
     <None Remove="ClientApp\src\app\models\transaction.list.response.ts" />
     <None Remove="ClientApp\src\app\models\transaction.model.ts" />
     <None Remove="ClientApp\src\app\models\transaction.view.model.ts" />
     <None Remove="ClientApp\src\app\models\update.response.ts" />
     <None Remove="ClientApp\src\app\register\register.component.ts" />
+    <None Remove="ClientApp\src\app\transactions\transactions.component.html~RF2011703.TMP" />
   </ItemGroup>
 
   <ItemGroup>
@@ -60,6 +62,7 @@
     <TypeScriptCompile Include="ClientApp\src\app\models\budget.model.ts" />
     <TypeScriptCompile Include="ClientApp\src\app\models\budget.list.response.ts" />
     <TypeScriptCompile Include="ClientApp\src\app\models\budget.view.model.ts" />
+    <TypeScriptCompile Include="ClientApp\src\app\models\delete.response.ts" />
     <TypeScriptCompile Include="ClientApp\src\app\models\transaction.view.model.ts" />
     <TypeScriptCompile Include="ClientApp\src\app\models\transaction.model.ts" />
     <TypeScriptCompile Include="ClientApp\src\app\models\transaction.list.response.ts" />

--- a/MyMoney.Web/Startup.cs
+++ b/MyMoney.Web/Startup.cs
@@ -34,6 +34,7 @@ namespace MyMoney.Web
             services.AddScoped<ITokenProvider, TokenProvider>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IRepository, Repository>();
+            services.AddScoped<IRelationRepository, RelationRepository>();
             services.AddScoped<IBudgetService, BudgetService>();
             services.AddScoped<ITransactionService, TransactionService>();
             services.AddScoped<IEntityFactory, EntityFactory>();


### PR DESCRIPTION
## Issues
closes #19 
closes #16 

## Overview of Changes
- Added `IRelationRepository` for adding and deleting relation entities. Relation entities are sub-types of `IRelationEntity`.
- Updated `ITransactionService` to reflect the changes to how budgets function.
- Added edit transaction page that functions similarly to the add page except that it loads the data of the transaction specified by the transaction id in the URL on init. it is accessed by liking the edit icon on a transaction.
- Added delete button to the transactions view page 
- Added `Find` endpoint to the TransactionController for finding a specific transaction
- Removed constructor for `DeleteRequest` as it was unneeded
- Added `FindRequest` for specifying the Id of an entity to be found