### PR TITLE
Refactored MonthId into Month and Year in backend

### DIFF
--- a/MyMoney.Core/Interfaces/Entities/IBudget.cs
+++ b/MyMoney.Core/Interfaces/Entities/IBudget.cs
@@ -4,7 +4,8 @@ namespace MyMoney.Core.Interfaces.Entities
 {
    public interface IBudget : IBaseEntity
    {
-      string MonthId { get; set; }
+      int Year { get; set; }
+      int Month { get; set; }
       decimal Amount { get; set; }
       string Name { get; set; }
       string Notes { get; set; }

--- a/MyMoney.Core/Services/BudgetService.cs
+++ b/MyMoney.Core/Services/BudgetService.cs
@@ -44,11 +44,18 @@ namespace MyMoney.Core.Services
             return null;
          }
 
+         var monthStr = monthId.Substring(4, 2);
+         var yearStr = monthId.Substring(0, 4);
+
+         var month = int.Parse(monthStr);
+         var year = int.Parse(yearStr);
+
          var budget = _entityFactory.NewBudget;
          budget.UserId = user.Id;
          budget.User = user;
          budget.Amount = amount;
-         budget.MonthId = monthId;
+         budget.Month = month;
+         budget.Year = year;
          budget.Notes = notes;
          budget.Name = name;
 
@@ -59,7 +66,13 @@ namespace MyMoney.Core.Services
       {
          var user = _currentUserProvider.CurrentUser;
 
-         return user.Budgets.Where(b => monthId == b.MonthId).ToList();
+         var monthStr = monthId.Substring(4, 2);
+         var yearStr = monthId.Substring(0, 4);
+
+         var month = int.Parse(monthStr);
+         var year = int.Parse(yearStr);
+
+         return user.Budgets.Where(b => month == b.Month && year == b.Year).ToList();
       }
 
       public bool Update(long budgetId, string monthId, string name, decimal amount, string notes)
@@ -73,10 +86,17 @@ namespace MyMoney.Core.Services
          if (budget == null || budget.UserId != userId)
             return false;
 
+         var monthStr = monthId.Substring(4, 2);
+         var yearStr = monthId.Substring(0, 4);
+
+         var month = int.Parse(monthStr);
+         var year = int.Parse(yearStr);
+
+         budget.Month = month;
+         budget.Year = year;
          budget.Amount = amount;
          budget.Notes = notes;
          budget.Name = name;
-         budget.MonthId = monthId;
 
          return _repository.Update(budget);
       }

--- a/MyMoney.Infrastructure/Entities/Budget.cs
+++ b/MyMoney.Infrastructure/Entities/Budget.cs
@@ -13,7 +13,6 @@ namespace MyMoney.Infrastructure.Entities
       public decimal Amount { get; set; }
       public string Notes { get; set; }
       public long UserId { get; set; }
-      public string MonthId { get; set; }
       public int Year { get; set; }
       public int Month { get; set; }
       public string Name { get; set; }

--- a/MyMoney.Infrastructure/Entities/Budget.cs
+++ b/MyMoney.Infrastructure/Entities/Budget.cs
@@ -14,6 +14,8 @@ namespace MyMoney.Infrastructure.Entities
       public string Notes { get; set; }
       public long UserId { get; set; }
       public string MonthId { get; set; }
+      public int Year { get; set; }
+      public int Month { get; set; }
       public string Name { get; set; }
 
       [NotMapped]

--- a/MyMoney.Infrastructure/EntityFramework/DatabaseSeeder.cs
+++ b/MyMoney.Infrastructure/EntityFramework/DatabaseSeeder.cs
@@ -1,4 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using MyMoney.Infrastructure.Entities;
+using System;
+using System.Linq;
 
 namespace MyMoney.Infrastructure.EntityFramework
 {
@@ -12,7 +15,25 @@ namespace MyMoney.Infrastructure.EntityFramework
 
       public static void Seed(DatabaseContext context)
       {
+         var budgets = context.Set<Budget>().AsEnumerable();
 
+         foreach (var budget in budgets)
+         {
+            var monthId = budget.MonthId;
+
+            var monthStr = monthId.Substring(4, 2);
+            var yearStr = monthId.Substring(0, 4);
+
+            var month = int.Parse(monthStr);
+            var year = int.Parse(yearStr);
+
+            budget.Month = month;
+            budget.Year = year;
+
+            Console.WriteLine($"MonthId:{monthId} -> Year:{year} Month:{month}");
+         }
+
+         context.SaveChanges();
       }
    }
 }

--- a/MyMoney.Infrastructure/EntityFramework/DatabaseSeeder.cs
+++ b/MyMoney.Infrastructure/EntityFramework/DatabaseSeeder.cs
@@ -15,25 +15,6 @@ namespace MyMoney.Infrastructure.EntityFramework
 
       public static void Seed(DatabaseContext context)
       {
-         var budgets = context.Set<Budget>().AsEnumerable();
-
-         foreach (var budget in budgets)
-         {
-            var monthId = budget.MonthId;
-
-            var monthStr = monthId.Substring(4, 2);
-            var yearStr = monthId.Substring(0, 4);
-
-            var month = int.Parse(monthStr);
-            var year = int.Parse(yearStr);
-
-            budget.Month = month;
-            budget.Year = year;
-
-            Console.WriteLine($"MonthId:{monthId} -> Year:{year} Month:{month}");
-         }
-
-         context.SaveChanges();
       }
    }
 }

--- a/MyMoney.Infrastructure/EntityFramework/DatabaseSeeder.cs
+++ b/MyMoney.Infrastructure/EntityFramework/DatabaseSeeder.cs
@@ -1,13 +1,16 @@
-﻿namespace MyMoney.Infrastructure.EntityFramework
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace MyMoney.Infrastructure.EntityFramework
 {
-   public sealed class DatabaseSeeder
+   public static class DatabaseSeeder
    {
-      public void EnsureCreated(DatabaseContext context)
+      public static void Setup(DatabaseContext context)
       {
          context.Database.EnsureCreated();
+         context.Database.Migrate();
       }
 
-      public void Seed(DatabaseContext context)
+      public static void Seed(DatabaseContext context)
       {
 
       }

--- a/MyMoney.Infrastructure/EntityFramework/DatabaseSeeder.cs
+++ b/MyMoney.Infrastructure/EntityFramework/DatabaseSeeder.cs
@@ -1,7 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using MyMoney.Infrastructure.Entities;
-using System;
-using System.Linq;
 
 namespace MyMoney.Infrastructure.EntityFramework
 {

--- a/MyMoney.Infrastructure/Migrations/20201025104308_AddMonthYearToBudget.Designer.cs
+++ b/MyMoney.Infrastructure/Migrations/20201025104308_AddMonthYearToBudget.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyMoney.Infrastructure.EntityFramework;
 
 namespace MyMoney.Infrastructure.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20201025104308_AddMonthYearToBudget")]
+    partial class AddMonthYearToBudget
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MyMoney.Infrastructure/Migrations/20201025104308_AddMonthYearToBudget.cs
+++ b/MyMoney.Infrastructure/Migrations/20201025104308_AddMonthYearToBudget.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace MyMoney.Infrastructure.Migrations
+{
+    public partial class AddMonthYearToBudget : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Month",
+                table: "Budgets",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Year",
+                table: "Budgets",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Month",
+                table: "Budgets");
+
+            migrationBuilder.DropColumn(
+                name: "Year",
+                table: "Budgets");
+        }
+    }
+}

--- a/MyMoney.Infrastructure/Migrations/20201025110827_RemoveMonthId.Designer.cs
+++ b/MyMoney.Infrastructure/Migrations/20201025110827_RemoveMonthId.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyMoney.Infrastructure.EntityFramework;
 
 namespace MyMoney.Infrastructure.Migrations
 {
    [DbContext(typeof(DatabaseContext))]
-   partial class DatabaseContextModelSnapshot : ModelSnapshot
+   [Migration("20201025110827_RemoveMonthId")]
+   partial class RemoveMonthId
    {
-      protected override void BuildModel(ModelBuilder modelBuilder)
+      protected override void BuildTargetModel(ModelBuilder modelBuilder)
       {
 #pragma warning disable 612, 618
          modelBuilder

--- a/MyMoney.Infrastructure/Migrations/20201025110827_RemoveMonthId.cs
+++ b/MyMoney.Infrastructure/Migrations/20201025110827_RemoveMonthId.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace MyMoney.Infrastructure.Migrations
+{
+   public partial class RemoveMonthId : Migration
+   {
+      protected override void Up(MigrationBuilder migrationBuilder)
+      {
+         migrationBuilder.DropColumn(
+             name: "MonthId",
+             table: "Budgets");
+      }
+
+      protected override void Down(MigrationBuilder migrationBuilder)
+      {
+         migrationBuilder.AddColumn<string>(
+             name: "MonthId",
+             table: "Budgets",
+             nullable: true);
+      }
+   }
+}

--- a/MyMoney.Web/ClientApp/src/app/shared/api/budget.api.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/api/budget.api.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
-import { IBudgetListResponseDto, IBudgetListRequestDto, IDeleteResponseDto, IBudgetDto, IIdDto, IUpdateResponseDto } from './dtos';
+import { IBudgetListResponseDto, IBudgetListRequestDto, IDeleteResponseDto, IBudgetDto, IIdDto, IUpdateResponseDto } from './dtos.interface';
 import { HttpHelper } from './http-helper.class';
 
 @Injectable({ providedIn: 'root' })

--- a/MyMoney.Web/ClientApp/src/app/shared/api/transaction.api.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/api/transaction.api.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
-import { IDeleteResponseDto, IIdDto, ITransactionDto, ITransactionListResponseDto, IUpdateResponseDto } from './dtos';
+import { IDeleteResponseDto, IIdDto, ITransactionDto, ITransactionListResponseDto, IUpdateResponseDto } from './dtos.interface';
 import { HttpHelper } from './http-helper.class';
 import { IDateRangeModel } from '../state/types';
 

--- a/MyMoney.Web/ClientApp/src/app/shared/api/user.api.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/api/user.api.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
-import { ILoginRequestDto, ILoginResponseDto, IRegisterRequestDto } from './dtos';
+import { ILoginRequestDto, ILoginResponseDto, IRegisterRequestDto } from './dtos.interface';
 import { HttpHelper } from './http-helper.class';
 
 @Injectable({ providedIn: 'root' })

--- a/MyMoney.Web/Models/Entity/BudgetModel.cs
+++ b/MyMoney.Web/Models/Entity/BudgetModel.cs
@@ -19,7 +19,7 @@ namespace MyMoney.Web.Models.Entity
       public BudgetModel(IBudget model) : base(model.Id)
       {
          Amount = model.Amount;
-         MonthId = model.MonthId;
+         MonthId = $"{model.Year}{(model.Month < 10 ? $"0{model.Month}" : $"{model.Month}")}";
          Name = model.Name;
          Notes = model.Notes;
          Remaining = model.Amount - model.Transactions.Select(b => b.Amount).Sum();

--- a/MyMoney.Web/Startup.cs
+++ b/MyMoney.Web/Startup.cs
@@ -127,7 +127,8 @@ namespace MyMoney.Web
          {
             using (var context = serviceScope.ServiceProvider.GetService<DatabaseContext>())
             {
-               context.Database.Migrate();
+               DatabaseSeeder.Setup(context);
+               DatabaseSeeder.Seed(context);
             }
          }
       }


### PR DESCRIPTION
Now the backend uses the `Month` and `Year` in as separate values in the database instead of a `MonthId`. This was initially added when I first created this app and was an inefficient way of storing data

Also fixed the module references in the client