### PR TITLE
Added income chart to home page

### DIFF
--- a/MyMoney.Core/Interfaces/Entities/IUser.cs
+++ b/MyMoney.Core/Interfaces/Entities/IUser.cs
@@ -14,7 +14,5 @@ namespace MyMoney.Core.Interfaces.Entities
       IQueryable<ITransaction> Transactions { get; }
       IQueryable<IBudget> Budgets { get; }
       IQueryable<IIncome> Incomes { get; }
-      IList<ITransaction> Between(DateTime start, DateTime end);
-      decimal Total(DateTime start, DateTime end);
    }
 }

--- a/MyMoney.Core/Interfaces/Service/IIncomeService.cs
+++ b/MyMoney.Core/Interfaces/Service/IIncomeService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using MyMoney.Core.Interfaces.Entities;
+using MyMoney.Core.Services;
 
 namespace MyMoney.Core.Interfaces.Service
 {
@@ -11,5 +12,6 @@ namespace MyMoney.Core.Interfaces.Service
       bool Delete(long incomeId);
       IIncome Find(long incomeId);
       IList<IIncome> From(DateTime start, int count);
+      IList<RunningTotal> RunningTotal(decimal initialTotal, DateTime start, DateTime end);
    }
 }

--- a/MyMoney.Core/Services/RunningTotal.cs
+++ b/MyMoney.Core/Services/RunningTotal.cs
@@ -1,0 +1,42 @@
+﻿using MyMoney.Core.Interfaces.Entities;
+using System;
+
+namespace MyMoney.Core.Services
+{
+   public class RunningTotal
+   {
+      public long Id { get; }
+      public bool IsTransaction { get; }
+      public bool IsIncome { get; }
+      public string Text { get; }
+      public DateTime Date { get; }
+      public decimal Delta { get; }
+      public decimal Value { get; private set; }
+
+      public RunningTotal(ITransaction transaction)
+      {
+         Id = transaction.Id;
+         IsIncome = false;
+         IsTransaction = true;
+         Text = transaction.Description;
+         Date = transaction.Date;
+         Delta = -transaction.Amount;
+      }
+
+      public RunningTotal(IIncome income)
+      {
+         Id = income.Id;
+         IsTransaction = false;
+         IsIncome = true;
+         Text = income.Name;
+         Date = income.Date;
+         Delta = income.Amount;
+      }
+
+      public decimal AdjustTotal(decimal runningTotal)
+      {
+         Value = runningTotal + Delta;
+         return Value;
+      }
+   }
+}

--- a/MyMoney.Core/Services/TransactionService.cs
+++ b/MyMoney.Core/Services/TransactionService.cs
@@ -35,7 +35,10 @@ namespace MyMoney.Core.Services
 
       public IList<ITransaction> Between(DateTime start, DateTime end)
       {
-         return _currentUserProvider.CurrentUser.Between(start, end);
+         return _currentUserProvider.CurrentUser.Transactions
+            .Where(t => t.Date >= start && t.Date <= end)
+            .OrderByDescending(t => t.Date)
+            .ToList(); ;
       }
 
       public ITransaction Add(DateTime date, string description, decimal amount, string notes, long[] budgetIds, long[] incomeIds)

--- a/MyMoney.Infrastructure/Entities/User.cs
+++ b/MyMoney.Infrastructure/Entities/User.cs
@@ -30,22 +30,6 @@ namespace MyMoney.Infrastructure.Entities
       public IQueryable<ITransaction> Transactions => TransactionsProxy.Cast<ITransaction>().AsQueryable();
       public virtual ICollection<Transaction> TransactionsProxy { get; set; } = new List<Transaction>();
 
-      public IList<ITransaction> Between(DateTime start, DateTime end)
-      {
-         return TransactionsProxy
-             .Where(t => t.Date >= start && t.Date <= end)
-             .OrderByDescending(t => t.Date)
-             .Cast<ITransaction>()
-             .ToList();
-      }
-
-      public decimal Total(DateTime start, DateTime end)
-      {
-         return TransactionsProxy
-             .Where(t => t.Date >= start && t.Date <= end)
-             .Aggregate((decimal)0, (total, transaction) => total + transaction.Amount);
-      }
-
       internal static void Configure(ModelBuilder model)
       {
          model.Entity<User>().HasIndex(t => new { t.Email }).IsUnique();

--- a/MyMoney.Web/ClientApp/src/app/app.module.ts
+++ b/MyMoney.Web/ClientApp/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { AuthenticationGuard } from './shared/guards/authenticated.guard';
 import { NgxChartsModule } from '@swimlane/ngx-charts';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LOGIN_PAGE_PATH, REGISTER_PAGE_PATH } from './shared/constants';
+import { ChartComponent } from './pages/home/chart/chart.component';
 
 @NgModule({
    declarations: [
@@ -41,7 +42,8 @@ import { LOGIN_PAGE_PATH, REGISTER_PAGE_PATH } from './shared/constants';
       EditBudgetsComponent,
       IncomesComponent,
       AddIncomesComponent,
-      EditIncomesComponent
+      EditIncomesComponent,
+      ChartComponent
    ],
    imports: [
       BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart-data-provider.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart-data-provider.interface.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 import { ISeriesItem } from 'src/app/shared/interfaces';
 import { ISeries } from 'src/app/shared/interfaces/series.interface';
 
-export interface IChartDataProvider<T> {
+export interface IChartDataProvider {
    xAxisLabel: string;
    yAxisLabel: string;
    colorScheme: { domain: string[] };
@@ -11,5 +11,4 @@ export interface IChartDataProvider<T> {
    onSelect(data: ISeriesItem): void;
    init(): void;
    destroy(): void;
-   search(searchParameters: T): void;
 }

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart-data-provider.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart-data-provider.interface.ts
@@ -1,0 +1,15 @@
+import { Observable } from 'rxjs';
+import { ISeriesItem } from 'src/app/shared/interfaces';
+import { ISeries } from 'src/app/shared/interfaces/series.interface';
+
+export interface IChartDataProvider<T> {
+   xAxisLabel: string;
+   yAxisLabel: string;
+   colorScheme: { domain: string[] };
+   seriesData: Observable<ISeries[]>;
+   legendTitle: string;
+   onSelect(data: ISeriesItem): void;
+   init(): void;
+   destroy(): void;
+   search(searchParameters: T): void;
+}

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
@@ -1,0 +1,7 @@
+<ngx-charts-line-chart [scheme]="dataProvider.colorScheme" [legend]="true" [showXAxisLabel]="true" [showYAxisLabel]="true" [xAxis]="true"
+   [yAxis]="true" [xAxisLabel]="dataProvider.xAxisLabel" [yAxisLabel]="dataProvider.yAxisLabel" [results]="dataProvider.seriesData | async"
+   [legendTitle]="dataProvider.legendTitle" (select)="onSelect($event)">
+   <ng-template #tooltipTemplate let-model="model">
+      {{ (model.id === -1 ? model.series : model.date) }} • {{ model.name }} • £{{ model.amount }}
+   </ng-template>
+</ngx-charts-line-chart>

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
@@ -1,7 +1,8 @@
 <div style="width: 100%; min-height: 500px; margin-bottom: 60px;">
    <ngx-charts-line-chart [scheme]="dataProvider.colorScheme" [legend]="showLegend" [showXAxisLabel]="true" [showYAxisLabel]="true"
-      [xAxis]="showXAxis" [yAxis]="true" [xAxisLabel]="dataProvider.xAxisLabel" [yAxisLabel]="dataProvider.yAxisLabel"
-      [results]="dataProvider.seriesData | async" [legendTitle]="dataProvider.legendTitle" (select)="onSelect($event)">
+      [xAxis]="true" [yAxis]="true" [xAxisLabel]="dataProvider.xAxisLabel" [yAxisLabel]="dataProvider.yAxisLabel"
+      [results]="dataProvider.seriesData | async" [legendTitle]="dataProvider.legendTitle" (select)="onSelect($event)"
+      [xAxisTickFormatting]="getXAxisTickLabel">
       <ng-template #tooltipTemplate let-model="model">
          {{ (model.id === -1 ? model.series : model.date) }} • {{ model.text }} • £{{ model.amount }}
       </ng-template>

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
@@ -1,6 +1,6 @@
 <div style="width: 100%; min-height: 500px;">
-   <ngx-charts-line-chart [scheme]="dataProvider.colorScheme" [legend]="true" [showXAxisLabel]="true" [showYAxisLabel]="true" [xAxis]="true"
-      [yAxis]="true" [xAxisLabel]="dataProvider.xAxisLabel" [yAxisLabel]="dataProvider.yAxisLabel"
+   <ngx-charts-line-chart [scheme]="dataProvider.colorScheme" [legend]="showLegend" [showXAxisLabel]="true" [showYAxisLabel]="true"
+      [xAxis]="showXAxis" [yAxis]="true" [xAxisLabel]="dataProvider.xAxisLabel" [yAxisLabel]="dataProvider.yAxisLabel"
       [results]="dataProvider.seriesData | async" [legendTitle]="dataProvider.legendTitle" (select)="onSelect($event)">
       <ng-template #tooltipTemplate let-model="model">
          {{ (model.id === -1 ? model.series : model.date) }} • {{ model.name }} • £{{ model.amount }}

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
@@ -1,9 +1,9 @@
-<div style="width: 100%; min-height: 500px;">
+<div style="width: 100%; min-height: 500px; margin-bottom: 60px;">
    <ngx-charts-line-chart [scheme]="dataProvider.colorScheme" [legend]="showLegend" [showXAxisLabel]="true" [showYAxisLabel]="true"
       [xAxis]="showXAxis" [yAxis]="true" [xAxisLabel]="dataProvider.xAxisLabel" [yAxisLabel]="dataProvider.yAxisLabel"
       [results]="dataProvider.seriesData | async" [legendTitle]="dataProvider.legendTitle" (select)="onSelect($event)">
       <ng-template #tooltipTemplate let-model="model">
-         {{ (model.id === -1 ? model.series : model.date) }} • {{ model.name }} • £{{ model.amount }}
+         {{ (model.id === -1 ? model.series : model.date) }} • {{ model.text }} • £{{ model.amount }}
       </ng-template>
    </ngx-charts-line-chart>
 </div>

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.html
@@ -1,7 +1,9 @@
-<ngx-charts-line-chart [scheme]="dataProvider.colorScheme" [legend]="true" [showXAxisLabel]="true" [showYAxisLabel]="true" [xAxis]="true"
-   [yAxis]="true" [xAxisLabel]="dataProvider.xAxisLabel" [yAxisLabel]="dataProvider.yAxisLabel" [results]="dataProvider.seriesData | async"
-   [legendTitle]="dataProvider.legendTitle" (select)="onSelect($event)">
-   <ng-template #tooltipTemplate let-model="model">
-      {{ (model.id === -1 ? model.series : model.date) }} • {{ model.name }} • £{{ model.amount }}
-   </ng-template>
-</ngx-charts-line-chart>
+<div style="width: 100%; min-height: 500px;">
+   <ngx-charts-line-chart [scheme]="dataProvider.colorScheme" [legend]="true" [showXAxisLabel]="true" [showYAxisLabel]="true" [xAxis]="true"
+      [yAxis]="true" [xAxisLabel]="dataProvider.xAxisLabel" [yAxisLabel]="dataProvider.yAxisLabel"
+      [results]="dataProvider.seriesData | async" [legendTitle]="dataProvider.legendTitle" (select)="onSelect($event)">
+      <ng-template #tooltipTemplate let-model="model">
+         {{ (model.id === -1 ? model.series : model.date) }} • {{ model.name }} • £{{ model.amount }}
+      </ng-template>
+   </ngx-charts-line-chart>
+</div>

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { ISeriesItem } from 'src/app/shared/interfaces';
+import { IChartDataProvider } from './chart-data-provider.interface';
+
+@Component({
+   templateUrl: './chart.component.html',
+   selector: 'mymoney-chart'
+})
+export class ChartComponent<T> {
+   @Input()
+   public dataProvider!: IChartDataProvider<T>;
+
+   constructor() { }
+
+   public onSelect(item: ISeriesItem): void {
+      this.dataProvider.onSelect(item);
+   }
+}

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.ts
@@ -11,14 +11,15 @@ export class ChartComponent {
    public dataProvider!: IChartDataProvider;
 
    @Input()
-   public showXAxis: boolean = true;
-
-   @Input()
    public showLegend: boolean = true;
 
    constructor() { }
 
    public onSelect(item: ISeriesItem): void {
       this.dataProvider.onSelect(item);
+   }
+
+   public getXAxisTickLabel(val: string): string {
+      return '';
    }
 }

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.ts
@@ -10,6 +10,12 @@ export class ChartComponent<T> {
    @Input()
    public dataProvider!: IChartDataProvider<T>;
 
+   @Input()
+   public showXAxis: boolean = true;
+
+   @Input()
+   public showLegend: boolean = true;
+
    constructor() { }
 
    public onSelect(item: ISeriesItem): void {

--- a/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/chart/chart.component.ts
@@ -6,9 +6,9 @@ import { IChartDataProvider } from './chart-data-provider.interface';
    templateUrl: './chart.component.html',
    selector: 'mymoney-chart'
 })
-export class ChartComponent<T> {
+export class ChartComponent {
    @Input()
-   public dataProvider!: IChartDataProvider<T>;
+   public dataProvider!: IChartDataProvider;
 
    @Input()
    public showXAxis: boolean = true;

--- a/MyMoney.Web/ClientApp/src/app/pages/home/home.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/home.component.html
@@ -1,1 +1,2 @@
 <mymoney-chart [dataProvider]="transactionsChart"></mymoney-chart>
+<mymoney-chart [dataProvider]="runningTotalChart" [showXAxis]="false" [showLegend]="false"></mymoney-chart>

--- a/MyMoney.Web/ClientApp/src/app/pages/home/home.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/home.component.html
@@ -1,2 +1,2 @@
 <mymoney-chart [dataProvider]="transactionsChart"></mymoney-chart>
-<mymoney-chart [dataProvider]="runningTotalChart" [showXAxis]="false" [showLegend]="false"></mymoney-chart>
+<mymoney-chart [dataProvider]="runningTotalChart" [showLegend]="false"></mymoney-chart>

--- a/MyMoney.Web/ClientApp/src/app/pages/home/home.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/home.component.html
@@ -1,9 +1,1 @@
-<div style="min-height: 500px;">
-   <ngx-charts-line-chart [scheme]="colorScheme" [legend]="true" [showXAxisLabel]="true" [showYAxisLabel]="true" [xAxis]="true"
-      [yAxis]="true" [xAxisLabel]="xAxisLabel" [yAxisLabel]="yAxisLabel" [results]="seriesData" [legendTitle]="legendTitle"
-      (select)="onSelect($event)">
-      <ng-template #tooltipTemplate let-model="model">
-         {{ (model.id === -1 ? model.series : model.date) }} • {{ model.name }} • £{{ model.amount }}
-      </ng-template>
-   </ngx-charts-line-chart>
-</div>
+<mymoney-chart [dataProvider]="transactionsChart"></mymoney-chart>

--- a/MyMoney.Web/ClientApp/src/app/pages/home/home.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/home.component.ts
@@ -18,7 +18,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       store: Store<IAppState>,
       router: Router,
    ) {
-      this.transactionsChart = new TransactionsChartDataProvider(transactionService, budgetService, store, router);
+      this.transactionsChart = new TransactionsChartDataProvider(transactionService, budgetService, router);
    }
 
    ngOnInit(): void {

--- a/MyMoney.Web/ClientApp/src/app/pages/home/home.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/home.component.ts
@@ -9,8 +9,8 @@ import { TransactionsChartDataProvider } from './transactions-chart-data-provide
    templateUrl: './home.component.html',
 })
 export class HomeComponent implements OnInit, OnDestroy {
-   public transactionsChart: IChartDataProvider<undefined>;
-   public runningTotalChart: IChartDataProvider<undefined>;
+   public transactionsChart: IChartDataProvider;
+   public runningTotalChart: IChartDataProvider;
 
    constructor(
       transactionService: TransactionService,
@@ -24,10 +24,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
    ngOnInit(): void {
       this.transactionsChart.init();
-      this.transactionsChart.search(undefined);
-
       this.runningTotalChart.init();
-      this.runningTotalChart.search(undefined)
    }
 
    ngOnDestroy(): void {

--- a/MyMoney.Web/ClientApp/src/app/pages/home/home.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/home.component.ts
@@ -1,97 +1,32 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { BudgetSeries, BudgetSeriesDataPoint } from 'src/app/shared/classes';
-import { ISeriesItem } from 'src/app/shared/interfaces';
 import { BudgetService, TransactionService } from 'src/app/shared/services';
 import { IAppState } from 'src/app/shared/state/app-state';
-import { selectBudgets } from 'src/app/shared/state/selectors/budget.selector';
-import { selectTransactions } from 'src/app/shared/state/selectors/transaction.selector';
-import { IBudgetModel, IDateRangeModel, ITransactionModel } from 'src/app/shared/state/types';
+import { IChartDataProvider } from './chart/chart-data-provider.interface';
+import { TransactionsChartDataProvider } from './transactions-chart-data-provider.class';
 
 @Component({
    templateUrl: './home.component.html',
 })
-export class HomeComponent implements OnInit {
-   public xAxisLabel: string;
-   public yAxisLabel: string;
-   public colorScheme: { domain: string[] };
-   public xAxisTicks: BudgetSeriesDataPoint[];
-   public seriesData: BudgetSeries[];
-   public legendTitle: string;
-
-   private budgets: IBudgetModel[];
-   private transactions: ITransactionModel[];
+export class HomeComponent implements OnInit, OnDestroy {
+   public transactionsChart: IChartDataProvider<undefined>;
 
    constructor(
-      private readonly transactionService: TransactionService,
-      private readonly budgetService: BudgetService,
-      private readonly store: Store<IAppState>,
-      private readonly router: Router,
+      transactionService: TransactionService,
+      budgetService: BudgetService,
+      store: Store<IAppState>,
+      router: Router,
    ) {
-      this.budgets = [];
-      this.transactions = [];
-      this.seriesData = [];
-      this.xAxisTicks = [];
-      this.xAxisLabel = 'Transactions';
-      this.yAxisLabel = 'Remaining in budget (£)';
-      this.colorScheme = {
-         domain: ['#5AA454', '#783320', '#DB2E2E', '#7aa3e5', '#a8385d', '#aae3f5']
-      };
-      this.legendTitle = new Date().toLocaleString('default', { month: 'long' });
+      this.transactionsChart = new TransactionsChartDataProvider(transactionService, budgetService, store, router);
    }
 
    ngOnInit(): void {
-
-      const month = new Date().getMonth() + 1;
-      const year = new Date().getFullYear();
-
-      this.budgetService.updateMonthId(month, year);
-
-      this.store
-         .select(selectBudgets)
-         .subscribe((budgets) => {
-            this.budgets = budgets;
-            this.transactionService.updateDateRange(this.defaultDateRange());
-         });
-
-      this.store
-         .select(selectTransactions)
-         .subscribe((transactions) => {
-            this.transactions = transactions.map(t => t).reverse();
-            this.updateCharts();
-         });
+      this.transactionsChart.init();
+      this.transactionsChart.search(undefined);
    }
 
-   defaultDateRange(): IDateRangeModel {
-      const end: Date = new Date();
-      end.setDate(1);
-      end.setMonth(end.getMonth() + 1);
-      end.setHours(0, 0, 0, 0);
-
-      const start: Date = new Date();
-      start.setDate(1);
-      start.setHours(0, 0, 0, 0);
-
-      return { end, start };
-   }
-
-   updateCharts() {
-
-      this.seriesData = [];
-
-      for (const budget of this.budgets) {
-         const bs = new BudgetSeries(budget);
-
-         for (const transaction of this.transactions) {
-            bs.addTransaction(transaction);
-         }
-
-         this.seriesData[this.seriesData.length] = bs;
-      }
-   }
-
-   onSelect(data: ISeriesItem): void {
-      this.router.navigate(['/transactions', 'edit', data.id]);
+   ngOnDestroy(): void {
+      this.transactionsChart.destroy();
    }
 }

--- a/MyMoney.Web/ClientApp/src/app/pages/home/home.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/home.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { Store } from '@ngrx/store';
-import { BudgetService, TransactionService } from 'src/app/shared/services';
-import { IAppState } from 'src/app/shared/state/app-state';
+import { BudgetService, IncomeService, TransactionService } from 'src/app/shared/services';
 import { IChartDataProvider } from './chart/chart-data-provider.interface';
+import { RunningTotalChartDataProvider } from './running-total-chart-data-provider.class';
 import { TransactionsChartDataProvider } from './transactions-chart-data-provider.class';
 
 @Component({
@@ -11,22 +10,28 @@ import { TransactionsChartDataProvider } from './transactions-chart-data-provide
 })
 export class HomeComponent implements OnInit, OnDestroy {
    public transactionsChart: IChartDataProvider<undefined>;
+   public runningTotalChart: IChartDataProvider<undefined>;
 
    constructor(
       transactionService: TransactionService,
       budgetService: BudgetService,
-      store: Store<IAppState>,
+      incomeService: IncomeService,
       router: Router,
    ) {
       this.transactionsChart = new TransactionsChartDataProvider(transactionService, budgetService, router);
+      this.runningTotalChart = new RunningTotalChartDataProvider(incomeService, router);
    }
 
    ngOnInit(): void {
       this.transactionsChart.init();
       this.transactionsChart.search(undefined);
+
+      this.runningTotalChart.init();
+      this.runningTotalChart.search(undefined)
    }
 
    ngOnDestroy(): void {
       this.transactionsChart.destroy();
+      this.runningTotalChart.destroy()
    }
 }

--- a/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
@@ -40,8 +40,8 @@ export class RunningTotalChartDataProvider implements IChartDataProvider<undefin
 
    }
 
-   public onSelect(data: ISeriesItem): void {
-      this.router.navigate(['/transactions', 'edit', data.id]);
+   public onSelect(item: ISeriesItem): void {
+      this.router.navigate(item.link);
    }
 
    public search(): void {

--- a/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
@@ -27,7 +27,7 @@ export class RunningTotalChartDataProvider implements IChartDataProvider<undefin
       this.xAxisLabel = 'Total savings';
       this.yAxisLabel = 'Balance (£)';
       this.colorScheme = {
-         domain: ['#5AA454', '#783320', '#DB2E2E', '#7aa3e5', '#a8385d', '#aae3f5']
+         domain: ['#7aa3e5']
       };
       this.legendTitle = '';
    }

--- a/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
@@ -8,7 +8,7 @@ import { ISeries } from 'src/app/shared/interfaces/series.interface';
 import { IRunningTotalDto } from 'src/app/shared/api';
 import { RunningTotalSeries } from 'src/app/shared/classes/running-total-series.class';
 
-export class RunningTotalChartDataProvider implements IChartDataProvider<undefined> {
+export class RunningTotalChartDataProvider implements IChartDataProvider {
    public xAxisLabel: string;
    public yAxisLabel: string;
    public colorScheme: { domain: string[] };
@@ -33,20 +33,16 @@ export class RunningTotalChartDataProvider implements IChartDataProvider<undefin
    }
 
    public init(): void {
-
+      this.budgetService.getRunningTotal(0, this.defaultDateRange())
+         .subscribe((runningTotalList) => this.updateChart(runningTotalList.runningTotals));
    }
 
    public destroy(): void {
-
+      // Do nothing
    }
 
    public onSelect(item: ISeriesItem): void {
       this.router.navigate(item.link);
-   }
-
-   public search(): void {
-      this.budgetService.getRunningTotal(0, this.defaultDateRange())
-         .subscribe((runningTotalList) => this.updateCharts(runningTotalList.runningTotals));
    }
 
    private defaultDateRange(): IDateRangeModel {
@@ -64,7 +60,7 @@ export class RunningTotalChartDataProvider implements IChartDataProvider<undefin
       return { end, start };
    }
 
-   private updateCharts(runningTotals: IRunningTotalDto[]): void {
+   private updateChart(runningTotals: IRunningTotalDto[]): void {
 
       const initialTotal = 0;
 

--- a/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
@@ -1,0 +1,79 @@
+import { IChartDataProvider } from './chart/chart-data-provider.interface';
+import { Router } from '@angular/router';
+import { ISeriesItem } from 'src/app/shared/interfaces';
+import { IncomeService } from 'src/app/shared/services';
+import { IDateRangeModel } from 'src/app/shared/state/types';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { ISeries } from 'src/app/shared/interfaces/series.interface';
+import { IRunningTotalDto } from 'src/app/shared/api';
+import { RunningTotalSeries } from 'src/app/shared/classes/running-total-series.class';
+
+export class RunningTotalChartDataProvider implements IChartDataProvider<undefined> {
+   public xAxisLabel: string;
+   public yAxisLabel: string;
+   public colorScheme: { domain: string[] };
+   public seriesData: Observable<ISeries[]>;
+   public legendTitle: string;
+
+   private seriesDataSubject: BehaviorSubject<ISeries[]>;
+
+   constructor(
+      private readonly budgetService: IncomeService,
+      private readonly router: Router,
+   ) {
+      this.seriesDataSubject = new BehaviorSubject<ISeries[]>([]);
+      this.seriesData = this.seriesDataSubject.asObservable();
+
+      this.xAxisLabel = 'Total savings';
+      this.yAxisLabel = 'Balance (£)';
+      this.colorScheme = {
+         domain: ['#5AA454', '#783320', '#DB2E2E', '#7aa3e5', '#a8385d', '#aae3f5']
+      };
+      this.legendTitle = '';
+   }
+
+   public init(): void {
+
+   }
+
+   public destroy(): void {
+
+   }
+
+   public onSelect(data: ISeriesItem): void {
+      this.router.navigate(['/transactions', 'edit', data.id]);
+   }
+
+   public search(): void {
+      this.budgetService.getRunningTotal(0, this.defaultDateRange())
+         .subscribe((runningTotalList) => this.updateCharts(runningTotalList.runningTotals));
+   }
+
+   private defaultDateRange(): IDateRangeModel {
+      const end: Date = new Date();
+      end.setDate(1);
+      end.setMonth(0);
+      end.setFullYear(end.getFullYear() + 1);
+      end.setHours(0, 0, 0, 0);
+
+      const start: Date = new Date();
+      start.setDate(1);
+      start.setMonth(0);
+      start.setHours(0, 0, 0, 0);
+
+      return { end, start };
+   }
+
+   private updateCharts(runningTotals: IRunningTotalDto[]): void {
+
+      const initialTotal = 0;
+
+      const series = new RunningTotalSeries(initialTotal);
+
+      for (const runningTotal of runningTotals) {
+         series.addEntry(runningTotal);
+      }
+
+      this.seriesDataSubject.next([series]);
+   }
+}

--- a/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/running-total-chart-data-provider.class.ts
@@ -24,7 +24,7 @@ export class RunningTotalChartDataProvider implements IChartDataProvider {
       this.seriesDataSubject = new BehaviorSubject<ISeries[]>([]);
       this.seriesData = this.seriesDataSubject.asObservable();
 
-      this.xAxisLabel = 'Total savings';
+      this.xAxisLabel = 'Total savings this year';
       this.yAxisLabel = 'Balance (£)';
       this.colorScheme = {
          domain: ['#7aa3e5']
@@ -61,10 +61,7 @@ export class RunningTotalChartDataProvider implements IChartDataProvider {
    }
 
    private updateChart(runningTotals: IRunningTotalDto[]): void {
-
-      const initialTotal = 0;
-
-      const series = new RunningTotalSeries(initialTotal);
+      const series = new RunningTotalSeries(0);
 
       for (const runningTotal of runningTotals) {
          series.addEntry(runningTotal);

--- a/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
@@ -7,7 +7,7 @@ import { IBudgetModel, IDateRangeModel, ITransactionModel } from 'src/app/shared
 import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
 import { ISeries } from 'src/app/shared/interfaces/series.interface';
 
-export class TransactionsChartDataProvider implements IChartDataProvider<undefined> {
+export class TransactionsChartDataProvider implements IChartDataProvider {
    public xAxisLabel: string;
    public yAxisLabel: string;
    public colorScheme: { domain: string[] };
@@ -15,7 +15,6 @@ export class TransactionsChartDataProvider implements IChartDataProvider<undefin
    public legendTitle: string;
 
    private seriesDataSubject: BehaviorSubject<ISeries[]>;
-   private unsubscribe: Subject<void>;
 
    constructor(
       private readonly transactionService: TransactionService,
@@ -24,7 +23,6 @@ export class TransactionsChartDataProvider implements IChartDataProvider<undefin
    ) {
       this.seriesDataSubject = new BehaviorSubject<ISeries[]>([]);
       this.seriesData = this.seriesDataSubject.asObservable();
-      this.unsubscribe = new Subject();
 
       this.xAxisLabel = 'Transactions';
       this.yAxisLabel = 'Remaining in budget (£)';
@@ -35,24 +33,19 @@ export class TransactionsChartDataProvider implements IChartDataProvider<undefin
    }
 
    public init(): void {
-
-   }
-
-   public destroy(): void {
-      this.unsubscribe.next();
-      this.unsubscribe.complete();
-   }
-
-   public onSelect(item: ISeriesItem): void {
-      this.router.navigate(item.link);
-   }
-
-   public search(): void {
       const month = new Date().getMonth() + 1;
       const year = new Date().getFullYear();
 
       combineLatest([this.budgetService.getBudgetsForMonth(month, year), this.transactionService.getTransactionsInRange(this.defaultDateRange())])
-         .subscribe(([budgetList, transactionList]) => this.updateCharts(budgetList.budgets, transactionList.transactions.reverse()));
+         .subscribe(([budgetList, transactionList]) => this.updateChart(budgetList.budgets, transactionList.transactions.reverse()));
+   }
+
+   public destroy(): void {
+      // Do nothing
+   }
+
+   public onSelect(item: ISeriesItem): void {
+      this.router.navigate(item.link);
    }
 
    private defaultDateRange(): IDateRangeModel {
@@ -68,7 +61,7 @@ export class TransactionsChartDataProvider implements IChartDataProvider<undefin
       return { end, start };
    }
 
-   private updateCharts(budgets: IBudgetModel[], transactions: ITransactionModel[]): void {
+   private updateChart(budgets: IBudgetModel[], transactions: ITransactionModel[]): void {
 
       const seriesData = [];
 

--- a/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
@@ -1,12 +1,8 @@
 import { IChartDataProvider } from './chart/chart-data-provider.interface';
 import { Router } from '@angular/router';
-import { Store } from '@ngrx/store';
 import { BudgetSeries } from 'src/app/shared/classes';
 import { ISeriesItem } from 'src/app/shared/interfaces';
 import { BudgetService, TransactionService } from 'src/app/shared/services';
-import { IAppState } from 'src/app/shared/state/app-state';
-import { selectBudgets } from 'src/app/shared/state/selectors/budget.selector';
-import { selectTransactions } from 'src/app/shared/state/selectors/transaction.selector';
 import { IBudgetModel, IDateRangeModel, ITransactionModel } from 'src/app/shared/state/types';
 import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
 import { ISeries } from 'src/app/shared/interfaces/series.interface';
@@ -24,7 +20,6 @@ export class TransactionsChartDataProvider implements IChartDataProvider<undefin
    constructor(
       private readonly transactionService: TransactionService,
       private readonly budgetService: BudgetService,
-      private readonly store: Store<IAppState>,
       private readonly router: Router,
    ) {
       this.seriesDataSubject = new BehaviorSubject<ISeries[]>([]);
@@ -40,8 +35,7 @@ export class TransactionsChartDataProvider implements IChartDataProvider<undefin
    }
 
    public init(): void {
-      combineLatest([this.store.select(selectBudgets), this.store.select(selectTransactions)])
-         .subscribe(([budgets, transactions]) => this.updateCharts(budgets, transactions.map(t => t).reverse()));
+
    }
 
    public destroy(): void {
@@ -57,8 +51,8 @@ export class TransactionsChartDataProvider implements IChartDataProvider<undefin
       const month = new Date().getMonth() + 1;
       const year = new Date().getFullYear();
 
-      this.budgetService.updateMonthId(month, year);
-      this.transactionService.updateDateRange(this.defaultDateRange());
+      combineLatest([this.budgetService.getBudgetsForMonth(month, year), this.transactionService.getTransactionsInRange(this.defaultDateRange())])
+         .subscribe(([budgetList, transactionList]) => this.updateCharts(budgetList.budgets, transactionList.transactions.reverse()));
    }
 
    private defaultDateRange(): IDateRangeModel {

--- a/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
@@ -65,8 +65,6 @@ export class TransactionsChartDataProvider implements IChartDataProvider<undefin
       start.setDate(1);
       start.setHours(0, 0, 0, 0);
 
-      console.log({ end, start });
-
       return { end, start };
    }
 

--- a/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
@@ -43,8 +43,8 @@ export class TransactionsChartDataProvider implements IChartDataProvider<undefin
       this.unsubscribe.complete();
    }
 
-   public onSelect(data: ISeriesItem): void {
-      this.router.navigate(['/transactions', 'edit', data.id]);
+   public onSelect(item: ISeriesItem): void {
+      this.router.navigate(item.link);
    }
 
    public search(): void {

--- a/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
@@ -69,7 +69,7 @@ export class TransactionsChartDataProvider implements IChartDataProvider {
          const bs = new BudgetSeries(budget);
 
          for (const transaction of transactions) {
-            bs.addTransaction(transaction);
+            bs.addEntry(transaction);
          }
 
          seriesData[seriesData.length] = bs as ISeries;

--- a/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
@@ -1,0 +1,93 @@
+import { IChartDataProvider } from './chart/chart-data-provider.interface';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { BudgetSeries, BudgetSeriesDataPoint } from 'src/app/shared/classes';
+import { ISeriesItem } from 'src/app/shared/interfaces';
+import { BudgetService, TransactionService } from 'src/app/shared/services';
+import { IAppState } from 'src/app/shared/state/app-state';
+import { selectBudgets } from 'src/app/shared/state/selectors/budget.selector';
+import { selectTransactions } from 'src/app/shared/state/selectors/transaction.selector';
+import { IBudgetModel, IDateRangeModel, ITransactionModel } from 'src/app/shared/state/types';
+import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
+import { ISeries } from 'src/app/shared/interfaces/series.interface';
+
+export class TransactionsChartDataProvider implements IChartDataProvider<Date> {
+   public xAxisLabel: string;
+   public yAxisLabel: string;
+   public colorScheme: { domain: string[] };
+   public seriesData: Observable<ISeries[]>;
+   public legendTitle: string;
+
+   private seriesDataSubject: BehaviorSubject<ISeries[]>;
+   private unsubscribe: Subject<void>;
+
+   constructor(
+      private readonly transactionService: TransactionService,
+      private readonly budgetService: BudgetService,
+      private readonly store: Store<IAppState>,
+      private readonly router: Router,
+   ) {
+      this.seriesDataSubject = new BehaviorSubject<ISeries[]>([]);
+      this.seriesData = this.seriesDataSubject.asObservable();
+      this.unsubscribe = new Subject();
+
+      this.xAxisLabel = 'Transactions';
+      this.yAxisLabel = 'Remaining in budget (£)';
+      this.colorScheme = {
+         domain: ['#5AA454', '#783320', '#DB2E2E', '#7aa3e5', '#a8385d', '#aae3f5']
+      };
+      this.legendTitle = new Date().toLocaleString('default', { month: 'long' });
+   }
+
+   public init(): void {
+      combineLatest([this.store.select(selectBudgets), this.store.select(selectTransactions)])
+         .subscribe(([budgets, transactions]) => this.updateCharts(budgets, transactions));
+   }
+
+   public destroy(): void {
+      this.unsubscribe.next();
+      this.unsubscribe.complete();
+   }
+
+   public onSelect(data: ISeriesItem): void {
+      this.router.navigate(['/transactions', 'edit', data.id]);
+   }
+
+   public search(now: Date): void {
+      const month = now.getMonth() + 1;
+      const year = now.getFullYear();
+
+      this.budgetService.updateMonthId(month, year);
+      this.transactionService.updateDateRange(this.defaultDateRange(now));
+   }
+
+   private defaultDateRange(now: Date): IDateRangeModel {
+      const end: Date = new Date(now);
+      end.setDate(1);
+      end.setMonth(end.getMonth() + 1);
+      end.setHours(0, 0, 0, 0);
+
+      const start: Date = new Date(now);
+      start.setDate(1);
+      start.setHours(0, 0, 0, 0);
+
+      return { end, start };
+   }
+
+   private updateCharts(budgets: IBudgetModel[], transactions: ITransactionModel[]): void {
+
+      const seriesData = [];
+
+      for (const budget of budgets) {
+         const bs = new BudgetSeries(budget);
+
+         for (const transaction of transactions) {
+            bs.addTransaction(transaction);
+         }
+
+         seriesData[seriesData.length] = bs as ISeries;
+      }
+
+      this.seriesDataSubject.next(seriesData);
+   }
+}

--- a/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/home/transactions-chart-data-provider.class.ts
@@ -1,7 +1,7 @@
 import { IChartDataProvider } from './chart/chart-data-provider.interface';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { BudgetSeries, BudgetSeriesDataPoint } from 'src/app/shared/classes';
+import { BudgetSeries } from 'src/app/shared/classes';
 import { ISeriesItem } from 'src/app/shared/interfaces';
 import { BudgetService, TransactionService } from 'src/app/shared/services';
 import { IAppState } from 'src/app/shared/state/app-state';
@@ -11,7 +11,7 @@ import { IBudgetModel, IDateRangeModel, ITransactionModel } from 'src/app/shared
 import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
 import { ISeries } from 'src/app/shared/interfaces/series.interface';
 
-export class TransactionsChartDataProvider implements IChartDataProvider<Date> {
+export class TransactionsChartDataProvider implements IChartDataProvider<undefined> {
    public xAxisLabel: string;
    public yAxisLabel: string;
    public colorScheme: { domain: string[] };
@@ -41,7 +41,7 @@ export class TransactionsChartDataProvider implements IChartDataProvider<Date> {
 
    public init(): void {
       combineLatest([this.store.select(selectBudgets), this.store.select(selectTransactions)])
-         .subscribe(([budgets, transactions]) => this.updateCharts(budgets, transactions));
+         .subscribe(([budgets, transactions]) => this.updateCharts(budgets, transactions.map(t => t).reverse()));
    }
 
    public destroy(): void {
@@ -53,23 +53,25 @@ export class TransactionsChartDataProvider implements IChartDataProvider<Date> {
       this.router.navigate(['/transactions', 'edit', data.id]);
    }
 
-   public search(now: Date): void {
-      const month = now.getMonth() + 1;
-      const year = now.getFullYear();
+   public search(): void {
+      const month = new Date().getMonth() + 1;
+      const year = new Date().getFullYear();
 
       this.budgetService.updateMonthId(month, year);
-      this.transactionService.updateDateRange(this.defaultDateRange(now));
+      this.transactionService.updateDateRange(this.defaultDateRange());
    }
 
-   private defaultDateRange(now: Date): IDateRangeModel {
-      const end: Date = new Date(now);
+   private defaultDateRange(): IDateRangeModel {
+      const end: Date = new Date();
       end.setDate(1);
       end.setMonth(end.getMonth() + 1);
       end.setHours(0, 0, 0, 0);
 
-      const start: Date = new Date(now);
+      const start: Date = new Date();
       start.setDate(1);
       start.setHours(0, 0, 0, 0);
+
+      console.log({ end, start });
 
       return { end, start };
    }

--- a/MyMoney.Web/ClientApp/src/app/shared/api/dtos.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/api/dtos.interface.ts
@@ -99,3 +99,7 @@ export interface IRunningTotalDto {
    delta: number;
    value: number;
 }
+
+export interface IRunningTotalListDto {
+   runningTotals: IRunningTotalDto[];
+}

--- a/MyMoney.Web/ClientApp/src/app/shared/api/dtos.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/api/dtos.interface.ts
@@ -84,3 +84,18 @@ export interface IUpdateResultDto {
    success: boolean;
    error: string;
 }
+
+export interface IRunningTotalSearchDto {
+   initialTotal: number;
+   dateRange: IDateRangeDto;
+}
+
+export interface IRunningTotalDto {
+   id: number;
+   isTransaction: boolean;
+   isIncome: boolean;
+   text: string;
+   date: string;
+   delta: number;
+   value: number;
+}

--- a/MyMoney.Web/ClientApp/src/app/shared/api/income.api.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/api/income.api.ts
@@ -7,7 +7,9 @@ import {
    IDeleteResultDto,
    IIncomeDto,
    IIdDto,
-   IUpdateResultDto
+   IUpdateResultDto,
+   IRunningTotalSearchDto,
+   IRunningTotalListDto
 } from './dtos.interface';
 import { HttpHelper } from './http-helper.class';
 
@@ -37,6 +39,12 @@ export class IncomeApi {
    public update(income: IIncomeDto): Observable<IUpdateResultDto> {
       return this.api
          .post<IIncomeDto, IUpdateResultDto>('/Income/Update', income)
+         .pipe(first());
+   }
+
+   public runningTotal(request: IRunningTotalSearchDto): Observable<IRunningTotalListDto> {
+      return this.api
+         .post<IRunningTotalSearchDto, IRunningTotalListDto>('/Income/RunningTotal', request)
          .pipe(first());
    }
 

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series-data-point.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series-data-point.class.ts
@@ -1,6 +1,7 @@
+import { ISeriesDataPoint } from '../interfaces/series-data-point.interface';
 import { ITransactionModel } from '../state/types';
 
-export class BudgetSeriesDataPoint {
+export class BudgetSeriesDataPoint implements ISeriesDataPoint {
    public readonly id: number;
    public readonly name: string;
    public readonly value: number;

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series-data-point.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series-data-point.class.ts
@@ -1,18 +1,27 @@
 import { ISeriesDataPoint } from '../interfaces/series-data-point.interface';
 import { ITransactionModel } from '../state/types';
 
+const DEFAULT_TEXT = 'Initial budget';
+
 export class BudgetSeriesDataPoint implements ISeriesDataPoint {
    public readonly id: number;
    public readonly name: string;
+   public readonly text: string;
    public readonly value: number;
    public readonly amount: number;
    public readonly date: string;
 
    constructor(transaction: ITransactionModel | null, remaining: number) {
       this.id = transaction?.id ?? -1;
-      this.name = transaction?.description ?? 'Initial budget';
+      this.text = transaction?.description ?? DEFAULT_TEXT;
       this.value = remaining;
       this.amount = transaction?.amount ?? remaining;
       this.date = transaction?.date ?? '';
+
+      if (transaction !== null) {
+         this.name = `Transaction ${transaction.id}`;
+      } else {
+         this.name = DEFAULT_TEXT;
+      }
    }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series-data-point.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series-data-point.class.ts
@@ -10,6 +10,7 @@ export class BudgetSeriesDataPoint implements ISeriesDataPoint {
    public readonly value: number;
    public readonly amount: number;
    public readonly date: string;
+   public readonly link: (string | number)[] | null;
 
    constructor(transaction: ITransactionModel | null, remaining: number) {
       this.id = transaction?.id ?? -1;
@@ -20,8 +21,10 @@ export class BudgetSeriesDataPoint implements ISeriesDataPoint {
 
       if (transaction !== null) {
          this.name = `Transaction ${transaction.id}`;
+         this.link = ['/transactions', 'edit', transaction.id];
       } else {
          this.name = DEFAULT_TEXT;
+         this.link = null;
       }
    }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series.class.ts
@@ -17,7 +17,7 @@ export class BudgetSeries implements ISeries {
       this.id = budget.id;
    }
 
-   public addTransaction(transaction: ITransactionModel) {
+   public addEntry(transaction: ITransactionModel) {
       if (transaction.budgetIds.includes(this.id)) {
          this.remaining -= transaction.amount;
       }

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series.class.ts
@@ -3,11 +3,11 @@ import { IBudgetModel, ITransactionModel } from '../state/types';
 import { BudgetSeriesDataPoint } from './budget-series-data-point.class';
 
 export class BudgetSeries implements ISeries {
-
-
-   public name: string;
+   public name: string; // Must be unique
+   public text: string;
    public series: BudgetSeriesDataPoint[];
    private remaining: number;
+
    private id: number;
 
    constructor(budget: IBudgetModel) {

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series.class.ts
@@ -4,10 +4,11 @@ import { BudgetSeriesDataPoint } from './budget-series-data-point.class';
 
 export class BudgetSeries implements ISeries {
 
-   public id: number;
+
    public name: string;
    public series: BudgetSeriesDataPoint[];
    private remaining: number;
+   private id: number;
 
    constructor(budget: IBudgetModel) {
       this.name = budget.name;

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/budget-series.class.ts
@@ -1,7 +1,8 @@
+import { ISeries } from '../interfaces/series.interface';
 import { IBudgetModel, ITransactionModel } from '../state/types';
 import { BudgetSeriesDataPoint } from './budget-series-data-point.class';
 
-export class BudgetSeries {
+export class BudgetSeries implements ISeries {
 
    public id: number;
    public name: string;

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series-data-point.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series-data-point.class.ts
@@ -1,18 +1,35 @@
 import { IRunningTotalDto } from '../api';
 import { ISeriesDataPoint } from '../interfaces/series-data-point.interface';
 
+const DEFAULT_TEXT = 'Initial total';
+
 export class RunningTotalSeriesDataPoint implements ISeriesDataPoint {
-   public readonly id: number;
    public readonly name: string;
+   public readonly text: string;
+   public readonly id: number;
    public readonly value: number;
    public readonly amount: number;
    public readonly date: string;
 
    constructor(runningTotal: IRunningTotalDto | null, initialTotal: number) {
       this.id = runningTotal?.id ?? -1;
-      this.name = runningTotal?.text ?? 'Initial total';
+      this.text = runningTotal?.text ?? DEFAULT_TEXT;
       this.value = runningTotal?.value ?? initialTotal;
       this.amount = runningTotal?.delta ?? 0;
       this.date = runningTotal?.date ?? '';
+
+      if (runningTotal !== null) {
+
+         if (runningTotal.isIncome) {
+            this.name = `Income ${runningTotal.id}`;
+         }
+
+         if (runningTotal.isTransaction) {
+            this.name = `Transaction ${runningTotal.id}`;
+         }
+
+      } else {
+         this.name = DEFAULT_TEXT;
+      }
    }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series-data-point.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series-data-point.class.ts
@@ -10,6 +10,7 @@ export class RunningTotalSeriesDataPoint implements ISeriesDataPoint {
    public readonly value: number;
    public readonly amount: number;
    public readonly date: string;
+   public readonly link: (string | number)[] | null;
 
    constructor(runningTotal: IRunningTotalDto | null, initialTotal: number) {
       this.id = runningTotal?.id ?? -1;
@@ -22,14 +23,16 @@ export class RunningTotalSeriesDataPoint implements ISeriesDataPoint {
 
          if (runningTotal.isIncome) {
             this.name = `Income ${runningTotal.id}`;
+            this.link = ['/incomes', 'edit', runningTotal.id];
          }
 
          if (runningTotal.isTransaction) {
             this.name = `Transaction ${runningTotal.id}`;
+            this.link = ['/transactions', 'edit', runningTotal.id];
          }
-
       } else {
          this.name = DEFAULT_TEXT;
+         this.link = null;
       }
    }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series-data-point.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series-data-point.class.ts
@@ -1,0 +1,18 @@
+import { IRunningTotalDto } from '../api';
+import { ISeriesDataPoint } from '../interfaces/series-data-point.interface';
+
+export class RunningTotalSeriesDataPoint implements ISeriesDataPoint {
+   public readonly id: number;
+   public readonly name: string;
+   public readonly value: number;
+   public readonly amount: number;
+   public readonly date: string;
+
+   constructor(runningTotal: IRunningTotalDto | null, initialTotal: number) {
+      this.id = runningTotal?.id ?? -1;
+      this.name = runningTotal?.text ?? 'Initial total';
+      this.value = runningTotal?.value ?? initialTotal;
+      this.amount = runningTotal?.delta ?? 0;
+      this.date = runningTotal?.date ?? '';
+   }
+}

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series.class.ts
@@ -1,12 +1,10 @@
 import { IRunningTotalDto } from '../api';
 import { ISeries } from '../interfaces/series.interface';
-import { BudgetSeriesDataPoint } from './budget-series-data-point.class';
 import { RunningTotalSeriesDataPoint } from './running-total-series-data-point.class';
 
 export class RunningTotalSeries implements ISeries {
-
    public name: string;
-   public series: BudgetSeriesDataPoint[];
+   public series: RunningTotalSeriesDataPoint[];
 
    private initialTotal: number;
 

--- a/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series.class.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/classes/running-total-series.class.ts
@@ -1,0 +1,22 @@
+import { IRunningTotalDto } from '../api';
+import { ISeries } from '../interfaces/series.interface';
+import { BudgetSeriesDataPoint } from './budget-series-data-point.class';
+import { RunningTotalSeriesDataPoint } from './running-total-series-data-point.class';
+
+export class RunningTotalSeries implements ISeries {
+
+   public name: string;
+   public series: BudgetSeriesDataPoint[];
+
+   private initialTotal: number;
+
+   constructor(initialTotal: number) {
+      this.name = "Running total";
+      this.initialTotal = initialTotal;
+      this.series = [new RunningTotalSeriesDataPoint(null, initialTotal)];
+   }
+
+   public addEntry(entry: IRunningTotalDto) {
+      this.series[this.series.length] = new RunningTotalSeriesDataPoint(entry, this.initialTotal);
+   }
+}

--- a/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-data-point.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-data-point.interface.ts
@@ -9,4 +9,5 @@ export interface ISeriesDataPoint {
    readonly value: number;
    readonly amount: number;
    readonly date: string;
+   readonly link: (string | number)[] | null;
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-data-point.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-data-point.interface.ts
@@ -1,0 +1,7 @@
+export interface ISeriesDataPoint {
+   readonly id: number;
+   readonly name: string;
+   readonly value: number;
+   readonly amount: number;
+   readonly date: string;
+}

--- a/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-data-point.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-data-point.interface.ts
@@ -1,6 +1,11 @@
 export interface ISeriesDataPoint {
-   readonly id: number;
+
+   /**
+    * The name id used by the chart to group data points.
+    */
    readonly name: string;
+   readonly id: number;
+   readonly text: string;
    readonly value: number;
    readonly amount: number;
    readonly date: string;

--- a/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-item.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-item.interface.ts
@@ -1,5 +1,7 @@
 export interface ISeriesItem {
    name: string;
+   text: string;
+   link: (string | number)[] | null;
    value: number;
    series: string;
    id: number;

--- a/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-item.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/interfaces/series-item.interface.ts
@@ -1,10 +1,3 @@
-export interface ISeriesItem {
-   name: string;
-   text: string;
-   link: (string | number)[] | null;
-   value: number;
-   series: string;
-   id: number;
-   amount: number;
-   date: string;
-}
+import { ISeriesDataPoint } from './series-data-point.interface';
+
+export type ISeriesItem = ISeriesDataPoint & { series: string; }

--- a/MyMoney.Web/ClientApp/src/app/shared/interfaces/series.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/interfaces/series.interface.ts
@@ -1,7 +1,6 @@
 import { ISeriesDataPoint } from './series-data-point.interface';
 
 export interface ISeries {
-   id: number;
    name: string;
    series: ISeriesDataPoint[];
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/interfaces/series.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/interfaces/series.interface.ts
@@ -1,0 +1,7 @@
+import { ISeriesDataPoint } from './series-data-point.interface';
+
+export interface ISeries {
+   id: number;
+   name: string;
+   series: ISeriesDataPoint[];
+}

--- a/MyMoney.Web/ClientApp/src/app/shared/services/income-service.service.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/services/income-service.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 import { concatAll, map } from 'rxjs/operators';
-import { IncomeApi, IDeleteResultDto, IIncomeListDto, IUpdateResultDto } from '../api';
+import { IncomeApi, IDeleteResultDto, IIncomeListDto, IUpdateResultDto, IDateRangeDto, IRunningTotalListDto } from '../api';
 import {
    DeleteIncomeAction,
    RefreshIncomesAction,
@@ -29,8 +29,12 @@ export class IncomeService {
       });
    }
 
-   public getIncomes(date: Date) {
+   public getIncomes(date: Date): Observable<IIncomeListDto> {
       return this.incomeApi.list({ date, count: 10 });
+   }
+
+   public getRunningTotal(initialTotal: number, dateRange: IDateRangeDto): Observable<IRunningTotalListDto> {
+      return this.incomeApi.runningTotal({ dateRange, initialTotal });
    }
 
    public deleteIncome(incomeId: number): void {

--- a/MyMoney.Web/ClientApp/src/app/shared/services/transaction-service.service.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/services/transaction-service.service.ts
@@ -18,10 +18,13 @@ export class TransactionService {
             return;
          }
 
-         this.transactionApi
-            .list(search.dateRange)
+         this.getTransactionsInRange(search.dateRange)
             .subscribe((response: ITransactionListDto) => this.store.dispatch(new SetTransactionsAction(response.transactions)));
       });
+   }
+
+   public getTransactionsInRange(dateRange: IDateRangeModel): Observable<ITransactionListDto> {
+      return this.transactionApi.list(dateRange);
    }
 
    public deleteTransaction(transactionId: number): void {

--- a/MyMoney.Web/Controllers/IncomeController.cs
+++ b/MyMoney.Web/Controllers/IncomeController.cs
@@ -72,6 +72,32 @@ namespace MyMoney.Web.Controllers
          }
       }
 
+      [HttpPost(nameof(RunningTotal))]
+      public IActionResult RunningTotal([FromBody] RunningTotalSearchDto dto)
+      {
+         try
+         {
+            if (dto == null || !ModelState.IsValid)
+            {
+               return BadRequest("Invalid State");
+            }
+
+            var runningTotals = _incomeService.RunningTotal(dto.InitialTotal, dto.dateRange.Start, dto.dateRange.End);
+
+            if (runningTotals == null)
+               return NotFound();
+
+            return Ok(new RunningTotalListDto
+            {
+               RunningTotals = runningTotals.Select(t => new RunningTotalDto(t)).ToList()
+            });
+         }
+         catch (Exception)
+         {
+            return BadRequest("Error while listing running total");
+         }
+      }
+
       [HttpPost(nameof(Add))]
       public IActionResult Add([FromBody] IncomeDto dto)
       {

--- a/MyMoney.Web/Models/Entity/RunningTotalDto.cs
+++ b/MyMoney.Web/Models/Entity/RunningTotalDto.cs
@@ -1,0 +1,25 @@
+﻿using MyMoney.Core.Services;
+using System;
+
+namespace MyMoney.Web.Models.Entity
+{
+   public class RunningTotalDto : EntityDto
+   {
+      public bool IsTransaction { get; }
+      public bool IsIncome { get; }
+      public string Text { get; }
+      public string Date { get; }
+      public decimal Delta { get; }
+      public decimal Value { get; private set; }
+
+      public RunningTotalDto(RunningTotal runningTotal): base(runningTotal.Id)
+      {
+         IsTransaction = runningTotal.IsTransaction;
+         IsIncome = runningTotal.IsIncome;
+         Text = runningTotal.Text;
+         Date = runningTotal.Date.ToShortDateString();
+         Delta = runningTotal.Delta;
+         Value = runningTotal.Value;
+      }
+   }
+}

--- a/MyMoney.Web/Models/Request/RunningTotalSearchDto.cs
+++ b/MyMoney.Web/Models/Request/RunningTotalSearchDto.cs
@@ -1,0 +1,14 @@
+﻿using MyMoney.Web.Models.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MyMoney.Web.Models.Request
+{
+   public class RunningTotalSearchDto
+   {
+      public decimal InitialTotal { get; set; }
+      public DateRangeDto dateRange { get; set; }
+   }
+}

--- a/MyMoney.Web/Models/Response/RunningTotalListDto.cs
+++ b/MyMoney.Web/Models/Response/RunningTotalListDto.cs
@@ -1,0 +1,10 @@
+﻿using MyMoney.Web.Models.Entity;
+using System.Collections.Generic;
+
+namespace MyMoney.Web.Models.Response
+{
+   public class RunningTotalListDto
+   {
+      public List<RunningTotalDto> RunningTotals { get; set; } = new List<RunningTotalDto>();
+   }
+}


### PR DESCRIPTION
closes #3 

## Changes
- Removed `Between` and `Total` from `IUser` as this functionality belongs in the `TransactionService` 
- Added `IncomeService.RunningTotal` which retrieves the combination of the transactions and incomes between a given date range, based on an initial value.
- Added `RunningTotal` as a data entity for the running total chart. This must be calculated server-side to improve performance.
- Added generic `ChartComponent` and `IChartDataProvider` to abstract the charts for reuse.
- Removed x-axis ticks as they need to be unique and if they are not the chart performs abnormally.
- Added dtos for searching for the running total
- Added `RunningTotalChartDataProvider` for populating the running total chart
- Added `TransactionsChartDataProvider` for populating the transactions chart
- Removed code from the home component into `TransactionsChartDataProvider`
- Added `ISeries`, `ISeriesItem` and `ISeriesDataPoint` as abstractions for the chart data