### PR TITLE
List incomes by date range

### DIFF
--- a/MyMoney.Core/Interfaces/Service/IIncomeService.cs
+++ b/MyMoney.Core/Interfaces/Service/IIncomeService.cs
@@ -12,6 +12,7 @@ namespace MyMoney.Core.Interfaces.Service
       bool Delete(long incomeId);
       IIncome Find(long incomeId);
       IList<IIncome> From(DateTime start, int count);
+      IList<IIncome> Between(DateTime start, DateTime end);
       IList<RunningTotal> RunningTotal(decimal initialTotal, DateTime start, DateTime end);
    }
 }

--- a/MyMoney.Core/Services/IncomeService.cs
+++ b/MyMoney.Core/Services/IncomeService.cs
@@ -57,7 +57,21 @@ namespace MyMoney.Core.Services
 
          var user = _currentUserProvider.CurrentUser;
 
-         return user.Incomes.Where(b => b.Date <= start).Take(count).ToList();
+         return user.Incomes
+            .Where(i => i.Date <= start)
+            .OrderByDescending(i => i.Date)
+            .Take(count)
+            .ToList();
+      }
+
+      public IList<IIncome> Between(DateTime start, DateTime end)
+      {
+         var user = _currentUserProvider.CurrentUser;
+
+         return user.Incomes
+            .Where(i => i.Date >= start && i.Date <= end)
+            .OrderByDescending(i => i.Date)
+            .ToList();
       }
 
       public IList<RunningTotal> RunningTotal(decimal initialTotal, DateTime start, DateTime end)

--- a/MyMoney.Web/ClientApp/src/app/pages/incomes/add/add.incomes.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/incomes/add/add.incomes.component.ts
@@ -22,13 +22,15 @@ export class AddIncomesComponent implements OnInit {
 
    public ngOnInit(): void {
       this.addIncomeForm = this.formBuilder.group({
-         date: ['', Validators.required],
+         date: [new Date().toISOString().split('T')[0], Validators.required],
          name: ['', Validators.required],
          amount: ['', Validators.required],
       });
    }
 
-   public get f() { return this.addIncomeForm.controls; }
+   public get f() {
+      return this.addIncomeForm.controls;
+   }
 
    public onSubmit(): void {
       this.submitted = true;

--- a/MyMoney.Web/ClientApp/src/app/pages/incomes/incomes.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/incomes/incomes.component.html
@@ -1,14 +1,24 @@
 <h2>Incomes</h2>
-<form [formGroup]="dateForm" (ngSubmit)="onSubmit()">
+<form [formGroup]="dateForm" (ngSubmit)="updateIncomes()">
    <div class="form-inline">
       <div class="input-group mb-3 pr-2">
          <div class="input-group-prepend">
-            <span class="input-group-text">Date</span>
+            <span class="input-group-text">Start</span>
          </div>
-         <input type="date" formControlName="date" class="form-control" (change)="updateIncomes()"
-            [ngClass]="{ 'is-invalid': submitted && f.date.errors }" />
-         <div *ngIf="submitted && f.date.errors" class="invalid-feedback">
-            <div *ngIf="f.date.errors.required">date is required</div>
+         <input type="date" formControlName="start" class="form-control" (change)="updateIncomes()"
+            [ngClass]="{ 'is-invalid': submitted && f.start.errors }" />
+         <div *ngIf="submitted && f.start.errors" class="invalid-feedback">
+            <div *ngIf="f.start.errors.required">Start is required</div>
+         </div>
+      </div>
+      <div class="input-group mb-3 pr-2">
+         <div class="input-group-prepend">
+            <span class="input-group-text">End</span>
+         </div>
+         <input type="date" formControlName="end" class="form-control" (change)="updateIncomes()"
+            [ngClass]="{ 'is-invalid': submitted && f.end.errors }" />
+         <div *ngIf="submitted && f.end.errors" class="invalid-feedback">
+            <div *ngIf="f.end.errors.required">End is required</div>
          </div>
       </div>
       <div class="input-group mb-3 pr-2 btn-group">

--- a/MyMoney.Web/ClientApp/src/app/pages/transactions/add/add.transactions.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/transactions/add/add.transactions.component.ts
@@ -38,7 +38,9 @@ export class AddTransactionsComponent implements OnInit {
       });
    }
 
-   public get f() { return this.addTransactionForm.controls; }
+   public get f() {
+      return this.addTransactionForm.controls;
+   }
 
    public onBudgetCheckboxChange(e, id): void {
       if (e.target.checked) {
@@ -66,7 +68,7 @@ export class AddTransactionsComponent implements OnInit {
          this.budgets = response.budgets.map(t => new BudgetViewModel(t));
       });
 
-      this.incomeService.getIncomes(date).subscribe(response => {
+      this.incomeService.getIncomesByDate(date).subscribe(response => {
          this.incomes = response.incomes.map(t => new IncomeViewModel(t));
       });
    }

--- a/MyMoney.Web/ClientApp/src/app/pages/transactions/add/add.transactions.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/transactions/add/add.transactions.component.ts
@@ -31,7 +31,7 @@ export class AddTransactionsComponent implements OnInit {
 
    public ngOnInit(): void {
       this.addTransactionForm = this.formBuilder.group({
-         date: ['', Validators.required],
+         date: [new Date().toISOString().split('T')[0], Validators.required],
          description: ['', Validators.required],
          amount: ['', Validators.required],
          notes: ['']

--- a/MyMoney.Web/ClientApp/src/app/pages/transactions/edit/edit.transactions.component.ts
+++ b/MyMoney.Web/ClientApp/src/app/pages/transactions/edit/edit.transactions.component.ts
@@ -119,7 +119,7 @@ export class EditTransactionsComponent implements OnInit {
          this.budgets = response.budgets.map(t => new BudgetViewModel(t));
       });
 
-      this.incomeService.getIncomes(date).subscribe(response => {
+      this.incomeService.getIncomesByDate(date).subscribe(response => {
          this.incomes = response.incomes.map(t => new IncomeViewModel(t));
       });
    }

--- a/MyMoney.Web/ClientApp/src/app/pages/transactions/transactions.component.html
+++ b/MyMoney.Web/ClientApp/src/app/pages/transactions/transactions.component.html
@@ -8,7 +8,7 @@
          <input type="date" formControlName="start" class="form-control" (change)="updateTransactions()"
             [ngClass]="{ 'is-invalid': submitted && f.start.errors }" />
          <div *ngIf="submitted && f.start.errors" class="invalid-feedback">
-            <div *ngIf="f.start.errors.required">start is required</div>
+            <div *ngIf="f.start.errors.required">Start is required</div>
          </div>
       </div>
       <div class="input-group mb-3 pr-2">
@@ -18,7 +18,7 @@
          <input type="date" formControlName="end" class="form-control" (change)="updateTransactions()"
             [ngClass]="{ 'is-invalid': submitted && f.end.errors }" />
          <div *ngIf="submitted && f.end.errors" class="invalid-feedback">
-            <div *ngIf="f.end.errors.required">end is required</div>
+            <div *ngIf="f.end.errors.required">End is required</div>
          </div>
       </div>
       <div class="input-group mb-3 pr-2 btn-group">

--- a/MyMoney.Web/ClientApp/src/app/shared/api/income.api.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/api/income.api.ts
@@ -3,13 +3,14 @@ import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import {
    IIncomeListDto,
-   IIncomeSearchDto,
    IDeleteResultDto,
    IIncomeDto,
    IIdDto,
    IUpdateResultDto,
    IRunningTotalSearchDto,
-   IRunningTotalListDto
+   IRunningTotalListDto,
+   IDateRangeDto,
+   IIncomeSearchDto
 } from './dtos.interface';
 import { HttpHelper } from './http-helper.class';
 
@@ -18,9 +19,15 @@ export class IncomeApi {
 
    constructor(private readonly api: HttpHelper) { }
 
-   public list(request: IIncomeSearchDto): Observable<IIncomeListDto> {
+   public list(request: IDateRangeDto): Observable<IIncomeListDto> {
       return this.api
-         .post<IIncomeSearchDto, IIncomeListDto>('/Income/List', request)
+         .post<IDateRangeDto, IIncomeListDto>('/Income/List', request)
+         .pipe(first());
+   }
+
+   public listCount(request: IIncomeSearchDto): Observable<IIncomeListDto> {
+      return this.api
+         .post<IIncomeSearchDto, IIncomeListDto>('/Income/ListCount', request)
          .pipe(first());
    }
 

--- a/MyMoney.Web/ClientApp/src/app/shared/services/income-service.service.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/services/income-service.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 import { concatAll, map } from 'rxjs/operators';
-import { IncomeApi, IDeleteResultDto, IIncomeListDto, IUpdateResultDto, IDateRangeDto, IRunningTotalListDto } from '../api';
+import { IncomeApi, IDeleteResultDto, IIncomeListDto, IUpdateResultDto, IRunningTotalListDto, IIncomeSearchDto } from '../api';
 import {
    DeleteIncomeAction,
    RefreshIncomesAction,
@@ -12,7 +12,7 @@ import {
 } from '../state/actions';
 import { IAppState } from '../state/app-state';
 import { selectIncomesSearchParameters, selectIncome } from '../state/selectors/income.selector';
-import { IIncomeModel, IIncomesSearch } from '../state/types';
+import { IDateRangeModel, IIncomeModel, IIncomesSearch } from '../state/types';
 
 
 @Injectable({ providedIn: 'root' })
@@ -24,16 +24,20 @@ export class IncomeService {
             return;
          }
 
-         this.getIncomes(search.date)
+         this.getIncomes(search.dateRange)
             .subscribe((response: IIncomeListDto) => this.store.dispatch(new SetIncomesAction(response.incomes)));
       });
    }
 
-   public getIncomes(date: Date): Observable<IIncomeListDto> {
-      return this.incomeApi.list({ date, count: 10 });
+   public getIncomes(dateRange: IDateRangeModel): Observable<IIncomeListDto> {
+      return this.incomeApi.list(dateRange);
    }
 
-   public getRunningTotal(initialTotal: number, dateRange: IDateRangeDto): Observable<IRunningTotalListDto> {
+   public getIncomesByDate(date: Date): Observable<IIncomeListDto> {
+      return this.incomeApi.listCount({ date, count: 10 });
+   }
+
+   public getRunningTotal(initialTotal: number, dateRange: IDateRangeModel): Observable<IRunningTotalListDto> {
       return this.incomeApi.runningTotal({ dateRange, initialTotal });
    }
 
@@ -47,8 +51,8 @@ export class IncomeService {
          });
    }
 
-   public updateDate(date: Date): void {
-      this.store.dispatch(new UpdateSearchDateAction(date));
+   public updateDate(dateRange: IDateRangeModel): void {
+      this.store.dispatch(new UpdateSearchDateAction(dateRange));
    }
 
    public addIncome(income: IIncomeModel): Observable<boolean> {

--- a/MyMoney.Web/ClientApp/src/app/shared/services/income-service.service.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/services/income-service.service.ts
@@ -8,7 +8,7 @@ import {
    RefreshIncomesAction,
    SetIncomesAction,
    UpdateIncomeAction,
-   UpdateSearchDateAction
+   UpdateIncomesSearchAction
 } from '../state/actions';
 import { IAppState } from '../state/app-state';
 import { selectIncomesSearchParameters, selectIncome } from '../state/selectors/income.selector';
@@ -52,7 +52,7 @@ export class IncomeService {
    }
 
    public updateDate(dateRange: IDateRangeModel): void {
-      this.store.dispatch(new UpdateSearchDateAction(dateRange));
+      this.store.dispatch(new UpdateIncomesSearchAction(dateRange));
    }
 
    public addIncome(income: IIncomeModel): Observable<boolean> {

--- a/MyMoney.Web/ClientApp/src/app/shared/services/transaction-service.service.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/services/transaction-service.service.ts
@@ -3,7 +3,13 @@ import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 import { concatAll, map } from 'rxjs/operators';
 import { TransactionApi, IDeleteResultDto, ITransactionListDto, IUpdateResultDto } from '../api';
-import { DeleteTransactionAction, RefreshTransactionsAction, SetTransactionsAction, UpdateDataRangeAction, UpdateTransactionAction } from '../state/actions';
+import {
+   DeleteTransactionAction,
+   RefreshTransactionsAction,
+   SetTransactionsAction,
+   UpdateDataRangeAction,
+   UpdateTransactionAction
+} from '../state/actions';
 import { IAppState } from '../state/app-state';
 import { selectTransactionsSearchParameters, selectTransaction } from '../state/selectors/transaction.selector';
 import { IDateRangeModel, ITransactionModel, ITransactionsSearch } from '../state/types';

--- a/MyMoney.Web/ClientApp/src/app/shared/state/actions/budgets.actions.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/actions/budgets.actions.ts
@@ -2,39 +2,39 @@ import { Action } from '@ngrx/store';
 import { IBudgetModel } from '../types';
 
 export enum BudgetActionTypes {
-   SetBudgets = 'Set Budgets',
-   UpdateBudget = 'Update Budget',
-   DeleteBudget = 'Delete Budget',
-   UpdateMonthId = 'Update Month Id',
-   RefreshBudgets = 'Refresh Budgets',
+   setBudgets = 'Set Budgets',
+   updateBudget = 'Update Budget',
+   deleteBudget = 'Delete Budget',
+   updateMonthId = 'Update Month Id',
+   refreshBudgets = 'Refresh Budgets',
 }
 
 export class SetBudgetsAction implements Action {
-   public type: string = BudgetActionTypes.SetBudgets;
+   public type: string = BudgetActionTypes.setBudgets;
 
    constructor(public readonly budgets: IBudgetModel[]) { }
 }
 
 export class UpdateBudgetAction implements Action {
-   public type: string = BudgetActionTypes.UpdateBudget;
+   public type: string = BudgetActionTypes.updateBudget;
 
    constructor(public readonly budget: IBudgetModel) { }
 }
 
 export class DeleteBudgetAction implements Action {
-   public type: string = BudgetActionTypes.DeleteBudget;
+   public type: string = BudgetActionTypes.deleteBudget;
 
    constructor(public readonly budgetId: number) { }
 }
 
 export class UpdateSearchMonthIdAction implements Action {
-   public type: string = BudgetActionTypes.UpdateMonthId;
+   public type: string = BudgetActionTypes.updateMonthId;
 
    constructor(public readonly month: number, public readonly year: number) { }
 }
 
 export class RefreshBudgetsAction implements Action {
-   public type: string = BudgetActionTypes.RefreshBudgets;
+   public type: string = BudgetActionTypes.refreshBudgets;
 
    constructor() { }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/state/actions/incomes.actions.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/actions/incomes.actions.ts
@@ -2,39 +2,39 @@ import { Action } from '@ngrx/store';
 import { IDateRangeModel, IIncomeModel } from '../types';
 
 export enum IncomeActionTypes {
-   SetIncomes = 'Set Incomes',
-   UpdateIncome = 'Update Income',
-   DeleteIncome = 'Delete Income',
-   UpdateSearchDate = 'Update Income Search Date',
-   RefreshIncomes = 'Refresh Incomes',
+   setIncomes = 'Set Incomes',
+   updateIncome = 'Update Income',
+   deleteIncome = 'Delete Income',
+   updateSearchDate = 'Update Income Search Date',
+   refreshIncomes = 'Refresh Incomes',
 }
 
 export class SetIncomesAction implements Action {
-   public type: string = IncomeActionTypes.SetIncomes;
+   public type: string = IncomeActionTypes.setIncomes;
 
    constructor(public readonly incomes: IIncomeModel[]) { }
 }
 
 export class UpdateIncomeAction implements Action {
-   public type: string = IncomeActionTypes.UpdateIncome;
+   public type: string = IncomeActionTypes.updateIncome;
 
    constructor(public readonly income: IIncomeModel) { }
 }
 
 export class DeleteIncomeAction implements Action {
-   public type: string = IncomeActionTypes.DeleteIncome;
+   public type: string = IncomeActionTypes.deleteIncome;
 
    constructor(public readonly incomeId: number) { }
 }
 
 export class UpdateSearchDateAction implements Action {
-   public type: string = IncomeActionTypes.UpdateSearchDate;
+   public type: string = IncomeActionTypes.updateSearchDate;
 
    constructor(public readonly dateRange: IDateRangeModel) { }
 }
 
 export class RefreshIncomesAction implements Action {
-   public type: string = IncomeActionTypes.RefreshIncomes;
+   public type: string = IncomeActionTypes.refreshIncomes;
 
    constructor() { }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/state/actions/incomes.actions.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/actions/incomes.actions.ts
@@ -27,7 +27,7 @@ export class DeleteIncomeAction implements Action {
    constructor(public readonly incomeId: number) { }
 }
 
-export class UpdateSearchDateAction implements Action {
+export class UpdateIncomesSearchAction implements Action {
    public type: string = IncomeActionTypes.updateSearchDate;
 
    constructor(public readonly dateRange: IDateRangeModel) { }

--- a/MyMoney.Web/ClientApp/src/app/shared/state/actions/incomes.actions.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/actions/incomes.actions.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-import { IIncomeModel } from '../types';
+import { IDateRangeModel, IIncomeModel } from '../types';
 
 export enum IncomeActionTypes {
    SetIncomes = 'Set Incomes',
@@ -30,7 +30,7 @@ export class DeleteIncomeAction implements Action {
 export class UpdateSearchDateAction implements Action {
    public type: string = IncomeActionTypes.UpdateSearchDate;
 
-   constructor(public readonly date: Date) { }
+   constructor(public readonly dateRange: IDateRangeModel) { }
 }
 
 export class RefreshIncomesAction implements Action {

--- a/MyMoney.Web/ClientApp/src/app/shared/state/actions/session.actions.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/actions/session.actions.ts
@@ -2,25 +2,25 @@ import { Action } from '@ngrx/store';
 import { IUserDto } from '../../api';
 
 export enum SessionActionTypes {
-   StartSession = 'Start login session',
-   ClearSession = 'Clear session',
-   SetUser = 'Set User',
+   startSession = 'Start login session',
+   clearSession = 'Clear session',
+   setUser = 'Set User',
 }
 
 export class StartSessionAction implements Action {
-   public type: string = SessionActionTypes.StartSession;
+   public type: string = SessionActionTypes.startSession;
 
    constructor(public readonly token: string, public readonly sessionEnd: string) { }
 }
 
 export class ClearSessionAction implements Action {
-   public type: string = SessionActionTypes.ClearSession;
+   public type: string = SessionActionTypes.clearSession;
 
    constructor() { }
 }
 
 export class SetUserAction implements Action {
-   public type: string = SessionActionTypes.SetUser;
+   public type: string = SessionActionTypes.setUser;
 
    constructor(public readonly user: IUserDto) { }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/state/actions/transactions.actions.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/actions/transactions.actions.ts
@@ -2,39 +2,39 @@ import { Action } from '@ngrx/store';
 import { IDateRangeModel, ITransactionModel } from '../types';
 
 export enum TransactionActionTypes {
-   SetTransactions = 'Set transactions',
-   UpdateTransaction = 'Update transaction',
-   DeleteTransaction = 'Delete transaction',
-   UpdateDataRange = 'Update Data Range',
-   RefreshTransactions = 'Refresh Transactions',
+   setTransactions = 'Set transactions',
+   updateTransaction = 'Update transaction',
+   deleteTransaction = 'Delete transaction',
+   updateDataRange = 'Update Data Range',
+   refreshTransactions = 'Refresh Transactions',
 }
 
 export class SetTransactionsAction implements Action {
-   public type: string = TransactionActionTypes.SetTransactions;
+   public type: string = TransactionActionTypes.setTransactions;
 
    constructor(public readonly transactions: ITransactionModel[]) { }
 }
 
 export class UpdateTransactionAction implements Action {
-   public type: string = TransactionActionTypes.UpdateTransaction;
+   public type: string = TransactionActionTypes.updateTransaction;
 
    constructor(public readonly transaction: ITransactionModel) { }
 }
 
 export class DeleteTransactionAction implements Action {
-   public type: string = TransactionActionTypes.DeleteTransaction;
+   public type: string = TransactionActionTypes.deleteTransaction;
 
    constructor(public readonly transactionId: number) { }
 }
 
 export class UpdateDataRangeAction implements Action {
-   public type: string = TransactionActionTypes.UpdateDataRange;
+   public type: string = TransactionActionTypes.updateDataRange;
 
    constructor(public readonly dateRange: IDateRangeModel) { }
 }
 
 export class RefreshTransactionsAction implements Action {
-   public type: string = TransactionActionTypes.RefreshTransactions;
+   public type: string = TransactionActionTypes.refreshTransactions;
 
    constructor() { }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/state/reducers/budget.reducer.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/reducers/budget.reducer.ts
@@ -25,21 +25,21 @@ export const initialBudgetState: IBudgetState = {
 export function budgetReducer(state: IBudgetState = initialBudgetState, action: Action): IBudgetState {
    switch (action.type) {
       case BudgetActionTypes.SetBudgets:
-         return SetBudgets(state, action as SetBudgetsAction);
+         return setBudgets(state, action as SetBudgetsAction);
       case BudgetActionTypes.UpdateBudget:
-         return UpdateBudget(state, action as UpdateBudgetAction);
+         return updateBudget(state, action as UpdateBudgetAction);
       case BudgetActionTypes.DeleteBudget:
-         return DeleteBudget(state, action as DeleteBudgetAction);
+         return deleteBudget(state, action as DeleteBudgetAction);
       case BudgetActionTypes.UpdateMonthId:
-         return UpdateSelectedMonth(state, action as UpdateSearchMonthIdAction);
+         return updateSelectedMonth(state, action as UpdateSearchMonthIdAction);
       case BudgetActionTypes.RefreshBudgets:
-         return RefreshBudgets(state);
+         return refreshBudgets(state);
       default:
          return state;
    }
 }
 
-function SetBudgets(state: IBudgetState, action: SetBudgetsAction): IBudgetState {
+function setBudgets(state: IBudgetState, action: SetBudgetsAction): IBudgetState {
    const budgets: IBudgetModel[] = action.budgets;
 
    return {
@@ -52,7 +52,7 @@ function SetBudgets(state: IBudgetState, action: SetBudgetsAction): IBudgetState
    };
 }
 
-function RefreshBudgets(state: IBudgetState): IBudgetState {
+function refreshBudgets(state: IBudgetState): IBudgetState {
    return {
       ...state,
       searchParameters: {
@@ -62,7 +62,7 @@ function RefreshBudgets(state: IBudgetState): IBudgetState {
    };
 }
 
-function UpdateBudget(state: IBudgetState, action: UpdateBudgetAction): IBudgetState {
+function updateBudget(state: IBudgetState, action: UpdateBudgetAction): IBudgetState {
    const budget: IBudgetModel = action.budget;
 
    const index = state.budgets.findIndex(t => t.id === budget.id);
@@ -77,7 +77,7 @@ function UpdateBudget(state: IBudgetState, action: UpdateBudgetAction): IBudgetS
    };
 }
 
-function DeleteBudget(state: IBudgetState, action: DeleteBudgetAction): IBudgetState {
+function deleteBudget(state: IBudgetState, action: DeleteBudgetAction): IBudgetState {
    const budgetId: number = action.budgetId;
 
    const index = state.budgets.findIndex(t => t.id === budgetId);
@@ -92,7 +92,7 @@ function DeleteBudget(state: IBudgetState, action: DeleteBudgetAction): IBudgetS
    };
 }
 
-function UpdateSelectedMonth(state: IBudgetState, action: UpdateSearchMonthIdAction): IBudgetState {
+function updateSelectedMonth(state: IBudgetState, action: UpdateSearchMonthIdAction): IBudgetState {
    const month: number = action.month;
    const year: number = action.year;
 

--- a/MyMoney.Web/ClientApp/src/app/shared/state/reducers/budget.reducer.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/reducers/budget.reducer.ts
@@ -8,37 +8,6 @@ import {
 } from '../actions';
 import { IBudgetModel, IBudgetsSearch } from '../types';
 
-export interface IBudgetState {
-   budgets: IBudgetModel[];
-   searchParameters: IBudgetsSearch;
-}
-
-export const initialBudgetState: IBudgetState = {
-   budgets: [],
-   searchParameters: {
-      month: new Date().getMonth() + 1,
-      year: new Date().getFullYear(),
-      refresh: true,
-   }
-};
-
-export function budgetReducer(state: IBudgetState = initialBudgetState, action: Action): IBudgetState {
-   switch (action.type) {
-      case BudgetActionTypes.SetBudgets:
-         return setBudgets(state, action as SetBudgetsAction);
-      case BudgetActionTypes.UpdateBudget:
-         return updateBudget(state, action as UpdateBudgetAction);
-      case BudgetActionTypes.DeleteBudget:
-         return deleteBudget(state, action as DeleteBudgetAction);
-      case BudgetActionTypes.UpdateMonthId:
-         return updateSelectedMonth(state, action as UpdateSearchMonthIdAction);
-      case BudgetActionTypes.RefreshBudgets:
-         return refreshBudgets(state);
-      default:
-         return state;
-   }
-}
-
 function setBudgets(state: IBudgetState, action: SetBudgetsAction): IBudgetState {
    const budgets: IBudgetModel[] = action.budgets;
 
@@ -105,4 +74,35 @@ function updateSelectedMonth(state: IBudgetState, action: UpdateSearchMonthIdAct
          refresh: true
       }
    };
+}
+
+export interface IBudgetState {
+   budgets: IBudgetModel[];
+   searchParameters: IBudgetsSearch;
+}
+
+export const initialBudgetState: IBudgetState = {
+   budgets: [],
+   searchParameters: {
+      month: new Date().getMonth() + 1,
+      year: new Date().getFullYear(),
+      refresh: true,
+   }
+};
+
+export function budgetReducer(state: IBudgetState = initialBudgetState, action: Action): IBudgetState {
+   switch (action.type) {
+      case BudgetActionTypes.setBudgets:
+         return setBudgets(state, action as SetBudgetsAction);
+      case BudgetActionTypes.updateBudget:
+         return updateBudget(state, action as UpdateBudgetAction);
+      case BudgetActionTypes.deleteBudget:
+         return deleteBudget(state, action as DeleteBudgetAction);
+      case BudgetActionTypes.updateMonthId:
+         return updateSelectedMonth(state, action as UpdateSearchMonthIdAction);
+      case BudgetActionTypes.refreshBudgets:
+         return refreshBudgets(state);
+      default:
+         return state;
+   }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/state/reducers/income.reducer.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/reducers/income.reducer.ts
@@ -8,36 +8,6 @@ import {
 } from '../actions';
 import { IDateRangeModel, IIncomeModel, IIncomesSearch } from '../types';
 
-export interface IIncomeState {
-   incomes: IIncomeModel[];
-   searchParameters: IIncomesSearch;
-}
-
-export const initialIncomeState: IIncomeState = {
-   incomes: [],
-   searchParameters: {
-      dateRange: defaultDateRange(),
-      refresh: true,
-   }
-};
-
-export function incomeReducer(state: IIncomeState = initialIncomeState, action: Action): IIncomeState {
-   switch (action.type) {
-      case IncomeActionTypes.SetIncomes:
-         return setIncomes(state, action as SetIncomesAction);
-      case IncomeActionTypes.UpdateIncome:
-         return updateIncome(state, action as UpdateIncomeAction);
-      case IncomeActionTypes.DeleteIncome:
-         return deleteIncome(state, action as DeleteIncomeAction);
-      case IncomeActionTypes.UpdateSearchDate:
-         return updateSelectedSearchDate(state, action as UpdateSearchDateAction);
-      case IncomeActionTypes.RefreshIncomes:
-         return refreshIncomes(state);
-      default:
-         return state;
-   }
-}
-
 function setIncomes(state: IIncomeState, action: SetIncomesAction): IIncomeState {
    const incomes: IIncomeModel[] = action.incomes;
 
@@ -111,4 +81,34 @@ function defaultDateRange(): IDateRangeModel {
    start.setMonth(start.getMonth() - 1);
 
    return { end, start };
+}
+
+export interface IIncomeState {
+   incomes: IIncomeModel[];
+   searchParameters: IIncomesSearch;
+}
+
+export const initialIncomeState: IIncomeState = {
+   incomes: [],
+   searchParameters: {
+      dateRange: defaultDateRange(),
+      refresh: true,
+   }
+};
+
+export function incomeReducer(state: IIncomeState = initialIncomeState, action: Action): IIncomeState {
+   switch (action.type) {
+      case IncomeActionTypes.setIncomes:
+         return setIncomes(state, action as SetIncomesAction);
+      case IncomeActionTypes.updateIncome:
+         return updateIncome(state, action as UpdateIncomeAction);
+      case IncomeActionTypes.deleteIncome:
+         return deleteIncome(state, action as DeleteIncomeAction);
+      case IncomeActionTypes.updateSearchDate:
+         return updateSelectedSearchDate(state, action as UpdateSearchDateAction);
+      case IncomeActionTypes.refreshIncomes:
+         return refreshIncomes(state);
+      default:
+         return state;
+   }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/state/reducers/income.reducer.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/reducers/income.reducer.ts
@@ -6,7 +6,7 @@ import {
    DeleteIncomeAction,
    UpdateSearchDateAction
 } from '../actions';
-import { IIncomeModel, IIncomesSearch } from '../types';
+import { IDateRangeModel, IIncomeModel, IIncomesSearch } from '../types';
 
 export interface IIncomeState {
    incomes: IIncomeModel[];
@@ -16,8 +16,7 @@ export interface IIncomeState {
 export const initialIncomeState: IIncomeState = {
    incomes: [],
    searchParameters: {
-      count: 20,
-      date: new Date(),
+      dateRange: defaultDateRange(),
       refresh: true,
    }
 };
@@ -25,21 +24,21 @@ export const initialIncomeState: IIncomeState = {
 export function incomeReducer(state: IIncomeState = initialIncomeState, action: Action): IIncomeState {
    switch (action.type) {
       case IncomeActionTypes.SetIncomes:
-         return SetIncomes(state, action as SetIncomesAction);
+         return setIncomes(state, action as SetIncomesAction);
       case IncomeActionTypes.UpdateIncome:
-         return UpdateIncome(state, action as UpdateIncomeAction);
+         return updateIncome(state, action as UpdateIncomeAction);
       case IncomeActionTypes.DeleteIncome:
-         return DeleteIncome(state, action as DeleteIncomeAction);
+         return deleteIncome(state, action as DeleteIncomeAction);
       case IncomeActionTypes.UpdateSearchDate:
-         return UpdateSelectedSearchDate(state, action as UpdateSearchDateAction);
+         return updateSelectedSearchDate(state, action as UpdateSearchDateAction);
       case IncomeActionTypes.RefreshIncomes:
-         return RefreshIncomes(state);
+         return refreshIncomes(state);
       default:
          return state;
    }
 }
 
-function SetIncomes(state: IIncomeState, action: SetIncomesAction): IIncomeState {
+function setIncomes(state: IIncomeState, action: SetIncomesAction): IIncomeState {
    const incomes: IIncomeModel[] = action.incomes;
 
    return {
@@ -52,7 +51,7 @@ function SetIncomes(state: IIncomeState, action: SetIncomesAction): IIncomeState
    };
 }
 
-function RefreshIncomes(state: IIncomeState): IIncomeState {
+function refreshIncomes(state: IIncomeState): IIncomeState {
    return {
       ...state,
       searchParameters: {
@@ -62,7 +61,7 @@ function RefreshIncomes(state: IIncomeState): IIncomeState {
    };
 }
 
-function UpdateIncome(state: IIncomeState, action: UpdateIncomeAction): IIncomeState {
+function updateIncome(state: IIncomeState, action: UpdateIncomeAction): IIncomeState {
    const income: IIncomeModel = action.income;
 
    const index = state.incomes.findIndex(t => t.id === income.id);
@@ -77,7 +76,7 @@ function UpdateIncome(state: IIncomeState, action: UpdateIncomeAction): IIncomeS
    };
 }
 
-function DeleteIncome(state: IIncomeState, action: DeleteIncomeAction): IIncomeState {
+function deleteIncome(state: IIncomeState, action: DeleteIncomeAction): IIncomeState {
    const incomeId: number = action.incomeId;
 
    const index = state.incomes.findIndex(t => t.id === incomeId);
@@ -92,15 +91,24 @@ function DeleteIncome(state: IIncomeState, action: DeleteIncomeAction): IIncomeS
    };
 }
 
-function UpdateSelectedSearchDate(state: IIncomeState, action: UpdateSearchDateAction): IIncomeState {
-   const date: Date = action.date;
+function updateSelectedSearchDate(state: IIncomeState, action: UpdateSearchDateAction): IIncomeState {
+   const dateRange: IDateRangeModel = action.dateRange;
 
    return {
       ...state,
       searchParameters: {
          ...state.searchParameters,
-         date,
+         dateRange,
          refresh: true
       }
    };
+}
+
+function defaultDateRange(): IDateRangeModel {
+   const end: Date = new Date();
+
+   const start: Date = new Date();
+   start.setMonth(start.getMonth() - 1);
+
+   return { end, start };
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/state/reducers/income.reducer.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/reducers/income.reducer.ts
@@ -4,7 +4,7 @@ import {
    UpdateIncomeAction,
    IncomeActionTypes,
    DeleteIncomeAction,
-   UpdateSearchDateAction
+   UpdateIncomesSearchAction
 } from '../actions';
 import { IDateRangeModel, IIncomeModel, IIncomesSearch } from '../types';
 
@@ -61,7 +61,7 @@ function deleteIncome(state: IIncomeState, action: DeleteIncomeAction): IIncomeS
    };
 }
 
-function updateSelectedSearchDate(state: IIncomeState, action: UpdateSearchDateAction): IIncomeState {
+function updateSelectedSearchDate(state: IIncomeState, action: UpdateIncomesSearchAction): IIncomeState {
    const dateRange: IDateRangeModel = action.dateRange;
 
    return {
@@ -105,7 +105,7 @@ export function incomeReducer(state: IIncomeState = initialIncomeState, action: 
       case IncomeActionTypes.deleteIncome:
          return deleteIncome(state, action as DeleteIncomeAction);
       case IncomeActionTypes.updateSearchDate:
-         return updateSelectedSearchDate(state, action as UpdateSearchDateAction);
+         return updateSelectedSearchDate(state, action as UpdateIncomesSearchAction);
       case IncomeActionTypes.refreshIncomes:
          return refreshIncomes(state);
       default:

--- a/MyMoney.Web/ClientApp/src/app/shared/state/reducers/session.reducer.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/reducers/session.reducer.ts
@@ -4,29 +4,6 @@ import { SESSION_LOCAL_STORAGE_KEY } from '../../constants';
 import { SessionActionTypes, StartSessionAction, ClearSessionAction, SetUserAction } from '../actions';
 import { ISessionModel, IUser } from '../types';
 
-export interface ISessionState {
-   currentSession: ISessionModel | null;
-   currentUser: IUser | null;
-}
-
-export const initialSessionState: ISessionState = {
-   currentSession: null,
-   currentUser: null
-};
-
-export function sessionReducer(state: ISessionState = initialSessionState, action: Action): ISessionState {
-   switch (action.type) {
-      case SessionActionTypes.StartSession:
-         return startSession(state, action as StartSessionAction);
-      case SessionActionTypes.ClearSession:
-         return clearSession(state, action as ClearSessionAction);
-      case SessionActionTypes.SetUser:
-         return setUser(state, action as SetUserAction);
-      default:
-         return state;
-   }
-}
-
 function startSession(state: ISessionState, action: StartSessionAction) {
 
    const token: string = action.token;
@@ -73,3 +50,25 @@ function clearSession(state: ISessionState, action: ClearSessionAction) {
    };
 }
 
+export interface ISessionState {
+   currentSession: ISessionModel | null;
+   currentUser: IUser | null;
+}
+
+export const initialSessionState: ISessionState = {
+   currentSession: null,
+   currentUser: null
+};
+
+export function sessionReducer(state: ISessionState = initialSessionState, action: Action): ISessionState {
+   switch (action.type) {
+      case SessionActionTypes.startSession:
+         return startSession(state, action as StartSessionAction);
+      case SessionActionTypes.clearSession:
+         return clearSession(state, action as ClearSessionAction);
+      case SessionActionTypes.setUser:
+         return setUser(state, action as SetUserAction);
+      default:
+         return state;
+   }
+}

--- a/MyMoney.Web/ClientApp/src/app/shared/state/reducers/transaction.reducer.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/reducers/transaction.reducer.ts
@@ -23,15 +23,15 @@ export const initialTransactionState: ITransactionState = {
 
 export function transactionReducer(state: ITransactionState = initialTransactionState, action: Action): ITransactionState {
    switch (action.type) {
-      case TransactionActionTypes.SetTransactions:
+      case TransactionActionTypes.setTransactions:
          return setTransactions(state, action as SetTransactionsAction);
-      case TransactionActionTypes.UpdateTransaction:
+      case TransactionActionTypes.updateTransaction:
          return updateTransaction(state, action as UpdateTransactionAction);
-      case TransactionActionTypes.DeleteTransaction:
+      case TransactionActionTypes.deleteTransaction:
          return deleteTransaction(state, action as DeleteTransactionAction);
-      case TransactionActionTypes.UpdateDataRange:
+      case TransactionActionTypes.updateDataRange:
          return updateDataRange(state, action as UpdateDataRangeAction);
-      case TransactionActionTypes.RefreshTransactions:
+      case TransactionActionTypes.refreshTransactions:
          return refreshTransactions(state);
       default:
          return state;

--- a/MyMoney.Web/ClientApp/src/app/shared/state/reducers/transaction.reducer.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/reducers/transaction.reducer.ts
@@ -8,36 +8,6 @@ import {
 } from '../actions';
 import { ITransactionModel, IDateRangeModel, ITransactionsSearch } from '../types';
 
-export interface ITransactionState {
-   transactions: ITransactionModel[];
-   searchParameters: ITransactionsSearch;
-}
-
-export const initialTransactionState: ITransactionState = {
-   transactions: [],
-   searchParameters: {
-      dateRange: defaultDateRange(),
-      refresh: true,
-   }
-};
-
-export function transactionReducer(state: ITransactionState = initialTransactionState, action: Action): ITransactionState {
-   switch (action.type) {
-      case TransactionActionTypes.setTransactions:
-         return setTransactions(state, action as SetTransactionsAction);
-      case TransactionActionTypes.updateTransaction:
-         return updateTransaction(state, action as UpdateTransactionAction);
-      case TransactionActionTypes.deleteTransaction:
-         return deleteTransaction(state, action as DeleteTransactionAction);
-      case TransactionActionTypes.updateDataRange:
-         return updateDataRange(state, action as UpdateDataRangeAction);
-      case TransactionActionTypes.refreshTransactions:
-         return refreshTransactions(state);
-      default:
-         return state;
-   }
-}
-
 function setTransactions(state: ITransactionState, action: SetTransactionsAction): ITransactionState {
    const transactions: ITransactionModel[] = action.transactions;
 
@@ -111,4 +81,34 @@ function defaultDateRange(): IDateRangeModel {
    start.setMonth(start.getMonth() - 1);
 
    return { end, start };
+}
+
+export interface ITransactionState {
+   transactions: ITransactionModel[];
+   searchParameters: ITransactionsSearch;
+}
+
+export const initialTransactionState: ITransactionState = {
+   transactions: [],
+   searchParameters: {
+      dateRange: defaultDateRange(),
+      refresh: true,
+   }
+};
+
+export function transactionReducer(state: ITransactionState = initialTransactionState, action: Action): ITransactionState {
+   switch (action.type) {
+      case TransactionActionTypes.setTransactions:
+         return setTransactions(state, action as SetTransactionsAction);
+      case TransactionActionTypes.updateTransaction:
+         return updateTransaction(state, action as UpdateTransactionAction);
+      case TransactionActionTypes.deleteTransaction:
+         return deleteTransaction(state, action as DeleteTransactionAction);
+      case TransactionActionTypes.updateDataRange:
+         return updateDataRange(state, action as UpdateDataRangeAction);
+      case TransactionActionTypes.refreshTransactions:
+         return refreshTransactions(state);
+      default:
+         return state;
+   }
 }

--- a/MyMoney.Web/ClientApp/src/app/shared/state/reducers/transaction.reducer.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/reducers/transaction.reducer.ts
@@ -24,21 +24,21 @@ export const initialTransactionState: ITransactionState = {
 export function transactionReducer(state: ITransactionState = initialTransactionState, action: Action): ITransactionState {
    switch (action.type) {
       case TransactionActionTypes.SetTransactions:
-         return SetTransactions(state, action as SetTransactionsAction);
+         return setTransactions(state, action as SetTransactionsAction);
       case TransactionActionTypes.UpdateTransaction:
-         return UpdateTransaction(state, action as UpdateTransactionAction);
+         return updateTransaction(state, action as UpdateTransactionAction);
       case TransactionActionTypes.DeleteTransaction:
-         return DeleteTransaction(state, action as DeleteTransactionAction);
+         return deleteTransaction(state, action as DeleteTransactionAction);
       case TransactionActionTypes.UpdateDataRange:
-         return UpdateDataRange(state, action as UpdateDataRangeAction);
+         return updateDataRange(state, action as UpdateDataRangeAction);
       case TransactionActionTypes.RefreshTransactions:
-         return RefreshTransactions(state);
+         return refreshTransactions(state);
       default:
          return state;
    }
 }
 
-function SetTransactions(state: ITransactionState, action: SetTransactionsAction): ITransactionState {
+function setTransactions(state: ITransactionState, action: SetTransactionsAction): ITransactionState {
    const transactions: ITransactionModel[] = action.transactions;
 
    return {
@@ -51,7 +51,7 @@ function SetTransactions(state: ITransactionState, action: SetTransactionsAction
    };
 }
 
-function RefreshTransactions(state: ITransactionState): ITransactionState {
+function refreshTransactions(state: ITransactionState): ITransactionState {
    return {
       ...state,
       searchParameters: {
@@ -61,7 +61,7 @@ function RefreshTransactions(state: ITransactionState): ITransactionState {
    };
 }
 
-function UpdateTransaction(state: ITransactionState, action: UpdateTransactionAction): ITransactionState {
+function updateTransaction(state: ITransactionState, action: UpdateTransactionAction): ITransactionState {
    const transaction: ITransactionModel = action.transaction;
 
    const index = state.transactions.findIndex(t => t.id === transaction.id);
@@ -76,7 +76,7 @@ function UpdateTransaction(state: ITransactionState, action: UpdateTransactionAc
    };
 }
 
-function DeleteTransaction(state: ITransactionState, action: DeleteTransactionAction): ITransactionState {
+function deleteTransaction(state: ITransactionState, action: DeleteTransactionAction): ITransactionState {
    const transactionId: number = action.transactionId;
 
    const index = state.transactions.findIndex(t => t.id === transactionId);
@@ -91,7 +91,7 @@ function DeleteTransaction(state: ITransactionState, action: DeleteTransactionAc
    };
 }
 
-function UpdateDataRange(state: ITransactionState, action: UpdateDataRangeAction): ITransactionState {
+function updateDataRange(state: ITransactionState, action: UpdateDataRangeAction): ITransactionState {
    const dateRange: IDateRangeModel = action.dateRange;
 
    return {

--- a/MyMoney.Web/ClientApp/src/app/shared/state/types/incomes-search-parameters.interface.ts
+++ b/MyMoney.Web/ClientApp/src/app/shared/state/types/incomes-search-parameters.interface.ts
@@ -1,5 +1,6 @@
+import { IDateRangeModel } from './date-range-model.interface';
+
 export interface IIncomesSearch {
-   date: Date;
-   count: number;
+   dateRange: IDateRangeModel;
    refresh: boolean;
 }

--- a/MyMoney.Web/Controllers/IncomeController.cs
+++ b/MyMoney.Web/Controllers/IncomeController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MyMoney.Core.Interfaces.Service;
+using MyMoney.Web.Models.Common;
 using MyMoney.Web.Models.Entity;
 using MyMoney.Web.Models.Request;
 using MyMoney.Web.Models.Response;
@@ -47,16 +48,42 @@ namespace MyMoney.Web.Controllers
       }
 
       [HttpPost(nameof(List))]
-      public IActionResult List([FromBody] IncomeSearchDto dto)
+      public IActionResult List([FromBody] DateRangeDto listParameters)
       {
          try
          {
-            if (dto == null || !ModelState.IsValid)
+            if (listParameters == null || !ModelState.IsValid)
             {
                return BadRequest("Invalid State");
             }
 
-            var incomes = _incomeService.From(dto.Date, dto.Count);
+            var incomes = _incomeService.Between(listParameters.Start, listParameters.End);
+
+            if (incomes == null)
+               return NotFound();
+
+            return Ok(new IncomeListDto
+            {
+               Incomes = incomes.Select(t => new IncomeDto(t)).ToList()
+            });
+         }
+         catch (Exception)
+         {
+            return BadRequest("Error while listing incomes");
+         }
+      }
+
+      [HttpPost(nameof(ListCount))]
+      public IActionResult ListCount([FromBody] IncomeSearchDto listParameters)
+      {
+         try
+         {
+            if (listParameters == null || !ModelState.IsValid)
+            {
+               return BadRequest("Invalid State");
+            }
+
+            var incomes = _incomeService.From(listParameters.Date, listParameters.Count);
 
             if (incomes == null)
                return NotFound();


### PR DESCRIPTION
closes #55 

## Changes
- Added ability to list incomes within a date range
- Listing a number of incomes prior to a given date now ordered them by date descending
- Renamed `List` endpoint to `ListCount` and added `List` for listing incomes within a date range
- Changed incomes page to search incomes using a date range
- Fixed state to store the date range
- Renamed all state reducer functions to be camel case
- Renamed all action types to be camel case
- Add income and transactions pages now default the date field to 'today'
- Renamed `UpdateSearchDateAction` to `UpdateIncomesSearchAction`