### PR TITLE
Improved generic chart interfaces and classes

### DIFF
--- a/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/pages/home/home.component.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/pages/home/home.component.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { BudgetService, TransactionService } from '../../shared/services';
 import { HomeService } from '../../shared/services/home.service';
-import { IChartDataProvider } from '../../shared/components/chart';
 import { RunningTotalChartDataProvider } from './running-total-chart-data-provider.class';
 import { TransactionsChartDataProvider } from './transactions-chart-data-provider.class';
 
@@ -10,8 +9,8 @@ import { TransactionsChartDataProvider } from './transactions-chart-data-provide
    templateUrl: './home.component.html',
 })
 export class HomeComponent implements OnInit, OnDestroy {
-   public transactionsChart: IChartDataProvider;
-   public runningTotalChart: IChartDataProvider;
+   public transactionsChart: TransactionsChartDataProvider;
+   public runningTotalChart: RunningTotalChartDataProvider;
 
    constructor(
       transactionService: TransactionService,

--- a/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/pages/home/running-total-chart-data-provider.class.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/pages/home/running-total-chart-data-provider.class.ts
@@ -1,33 +1,34 @@
 import { IChartDataProvider } from '../../shared/components/chart';
 import { Router } from '@angular/router';
-import { ISeriesItem, ISeries } from '@mymoney-common/interfaces';
 import { HomeService } from '../../shared/services';
 import { IDateRangeModel } from '../../shared/state/types';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { IRunningTotalDto } from '@mymoney-common/api';
-import { RunningTotalSeries } from '@mymoney-common/classes';
+import { RunningTotalSeries, RunningTotalSeriesDataPoint } from '@mymoney-common/classes';
 
-export class RunningTotalChartDataProvider implements IChartDataProvider {
+const LINE_COLOR = '#7aa3e5';
+
+export class RunningTotalChartDataProvider implements IChartDataProvider<RunningTotalSeries, RunningTotalSeriesDataPoint> {
    public chartTitle: string;
    public yAxisLabel: string;
    public colorScheme: { domain: string[] };
-   public seriesData: Observable<ISeries[]>;
+   public seriesData: Observable<RunningTotalSeries[]>;
    public subChartTitle: string;
 
-   private seriesDataSubject: BehaviorSubject<ISeries[]>;
+   private seriesDataSubject: BehaviorSubject<RunningTotalSeries[]>;
    private year: number;
 
    constructor(
       private readonly homeService: HomeService,
       private readonly router: Router
    ) {
-      this.seriesDataSubject = new BehaviorSubject<ISeries[]>([]);
+      this.seriesDataSubject = new BehaviorSubject<RunningTotalSeries[]>([]);
       this.seriesData = this.seriesDataSubject.asObservable();
       this.subChartTitle = '';
       this.chartTitle = 'Total savings';
       this.yAxisLabel = 'Balance (£)';
       this.colorScheme = {
-         domain: ['#7aa3e5'],
+         domain: [LINE_COLOR],
       };
       this.year = new Date().getFullYear();
    }
@@ -40,8 +41,30 @@ export class RunningTotalChartDataProvider implements IChartDataProvider {
       // Do nothing
    }
 
-   public onSelect(item: ISeriesItem): void {
-      this.router.navigate(item.link ?? ['./']);
+   public onSelect(item: RunningTotalSeriesDataPoint): void {
+      if (item.runningTotal !== null) {
+         if (item.amount > 0) {
+            if (item.runningTotal.parentId === null || item.id > 0) {
+               this.router.navigate(['/incomes', 'edit', item.id]);
+            } else {
+               this.router.navigate([
+                  '/incomes',
+                  'edit-recurring',
+                  item.runningTotal.parentId,
+               ]);
+            }
+         } else if (item.amount < 0) {
+            if (item.runningTotal.parentId === null || item.id > 0) {
+               this.router.navigate(['/transactions', 'edit', item.id]);
+            } else {
+               this.router.navigate([
+                  '/transactions',
+                  'edit-recurring',
+                  item.runningTotal.parentId,
+               ]);
+            }
+         }
+      }
    }
 
    public next(): void {
@@ -81,7 +104,7 @@ export class RunningTotalChartDataProvider implements IChartDataProvider {
    }
 
    private updateChart(runningTotals: IRunningTotalDto[]): void {
-      const series = new RunningTotalSeries(0);
+      const series = new RunningTotalSeries(0, LINE_COLOR);
 
       for (const runningTotal of runningTotals) {
          series.addEntry(runningTotal);

--- a/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/pages/home/running-total-chart-data-provider.class.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/pages/home/running-total-chart-data-provider.class.ts
@@ -2,28 +2,31 @@ import { IChartDataProvider } from '../../shared/components/chart';
 import { Router } from '@angular/router';
 import { HomeService } from '../../shared/services';
 import { IDateRangeModel } from '../../shared/state/types';
-import { BehaviorSubject, Observable } from 'rxjs';
 import { IRunningTotalDto } from '@mymoney-common/api';
-import { RunningTotalSeries, RunningTotalSeriesDataPoint } from '@mymoney-common/classes';
+import {
+   RunningTotalSeries,
+   RunningTotalSeriesDataPoint,
+} from '@mymoney-common/classes';
 
 const LINE_COLOR = '#7aa3e5';
 
-export class RunningTotalChartDataProvider implements IChartDataProvider<RunningTotalSeries, RunningTotalSeriesDataPoint> {
+export class RunningTotalChartDataProvider
+   implements
+      IChartDataProvider<RunningTotalSeries, RunningTotalSeriesDataPoint>
+{
    public chartTitle: string;
    public yAxisLabel: string;
    public colorScheme: { domain: string[] };
-   public seriesData: Observable<RunningTotalSeries[]>;
+   public series: RunningTotalSeries[];
    public subChartTitle: string;
 
-   private seriesDataSubject: BehaviorSubject<RunningTotalSeries[]>;
    private year: number;
 
    constructor(
       private readonly homeService: HomeService,
       private readonly router: Router
    ) {
-      this.seriesDataSubject = new BehaviorSubject<RunningTotalSeries[]>([]);
-      this.seriesData = this.seriesDataSubject.asObservable();
+      this.series = [];
       this.subChartTitle = '';
       this.chartTitle = 'Total savings';
       this.yAxisLabel = 'Balance (£)';
@@ -110,6 +113,6 @@ export class RunningTotalChartDataProvider implements IChartDataProvider<Running
          series.addEntry(runningTotal);
       }
 
-      this.seriesDataSubject.next([series]);
+      this.series = [series];
    }
 }

--- a/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/pages/home/transactions-chart-data-provider.class.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/pages/home/transactions-chart-data-provider.class.ts
@@ -7,7 +7,7 @@ import {
    IDateRangeModel,
    ITransactionModel,
 } from '../../shared/state/types';
-import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import { combineLatest } from 'rxjs';
 import { randomColor } from '@mymoney-common/functions';
 
 export class TransactionsChartDataProvider
@@ -16,10 +16,9 @@ export class TransactionsChartDataProvider
    public chartTitle: string;
    public yAxisLabel: string;
    public colorScheme: { domain: string[] };
-   public seriesData: Observable<BudgetSeries[]>;
+   public series: BudgetSeries[];
    public subChartTitle: string;
 
-   private seriesDataSubject: BehaviorSubject<BudgetSeries[]>;
    private month: Date;
 
    constructor(
@@ -27,8 +26,7 @@ export class TransactionsChartDataProvider
       private readonly budgetService: BudgetService,
       private readonly router: Router
    ) {
-      this.seriesDataSubject = new BehaviorSubject<BudgetSeries[]>([]);
-      this.seriesData = this.seriesDataSubject.asObservable();
+      this.series = [];
       this.subChartTitle = '';
       this.chartTitle = 'Transactions';
       this.yAxisLabel = 'Remaining in budget (£)';
@@ -129,8 +127,8 @@ export class TransactionsChartDataProvider
          seriesData[seriesData.length] = bs;
       }
 
-      this.seriesDataSubject.next(seriesData);
-      this.colorScheme = { domain: colors }
+      this.series = seriesData;
+      this.colorScheme = { domain: colors };
    }
 
    private getColourScheme(budgetCount: number): string[] {

--- a/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart-data-provider.interface.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart-data-provider.interface.ts
@@ -1,13 +1,13 @@
+import { ISeries, ISeriesDataPoint } from '@mymoney-common/interfaces';
 import { Observable } from 'rxjs';
-import { ISeriesItem, ISeries } from '@mymoney-common/interfaces';
 
-export interface IChartDataProvider {
+export interface IChartDataProvider<TSeries extends ISeries<TDataPoint>, TDataPoint extends ISeriesDataPoint> {
    chartTitle: string;
    yAxisLabel: string;
    colorScheme: { domain: string[] };
-   seriesData: Observable<ISeries[]>;
+   seriesData: Observable<TSeries[]>;
    subChartTitle: string;
-   onSelect(data: ISeriesItem): void;
+   onSelect(data: TDataPoint): void;
    init(): void;
    destroy(): void;
    next(): void;

--- a/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart-data-provider.interface.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart-data-provider.interface.ts
@@ -1,11 +1,13 @@
 import { ISeries, ISeriesDataPoint } from '@mymoney-common/interfaces';
-import { Observable } from 'rxjs';
 
-export interface IChartDataProvider<TSeries extends ISeries<TDataPoint>, TDataPoint extends ISeriesDataPoint> {
+export interface IChartDataProvider<
+   TSeries extends ISeries<TDataPoint>,
+   TDataPoint extends ISeriesDataPoint
+> {
    chartTitle: string;
    yAxisLabel: string;
    colorScheme: { domain: string[] };
-   seriesData: Observable<TSeries[]>;
+   series: TSeries[];
    subChartTitle: string;
    onSelect(data: TDataPoint): void;
    init(): void;

--- a/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart.component.html
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart.component.html
@@ -44,7 +44,7 @@
       [xAxis]="true"
       [yAxis]="true"
       [yAxisLabel]="dataProvider.yAxisLabel"
-      [results]="dataProvider.seriesData | async"
+      [results]="dataProvider.series"
       [legendTitle]="''"
       (select)="onSelect($event)"
       [xAxisTickFormatting]="getXAxisTickLabel"

--- a/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart.component.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart.component.ts
@@ -1,22 +1,22 @@
 import { Component, Input } from '@angular/core';
-import { ISeriesItem } from '@mymoney-common/interfaces';
 import { IChartDataProvider } from './chart-data-provider.interface';
 import { LegendPosition } from '@swimlane/ngx-charts';
+import { ISeries, ISeriesDataPoint } from '@mymoney-common/interfaces';
 
 @Component({
    templateUrl: './chart.component.html',
    selector: 'mymoney-chart',
 })
-export class ChartComponent {
+export class ChartComponent<TSeries extends ISeries<TDataPoint>, TDataPoint extends ISeriesDataPoint> {
    @Input()
-   public dataProvider!: IChartDataProvider;
+   public dataProvider!: IChartDataProvider<TSeries, TDataPoint>;
 
    @Input()
    public showLegend = true;
 
    public LegendPosition = LegendPosition;
 
-   public onSelect(item: ISeriesItem): void {
+   public onSelect(item: TDataPoint): void {
       this.dataProvider.onSelect(item);
    }
 

--- a/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart.component.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-angular/src/app/shared/components/chart/chart.component.ts
@@ -7,7 +7,10 @@ import { ISeries, ISeriesDataPoint } from '@mymoney-common/interfaces';
    templateUrl: './chart.component.html',
    selector: 'mymoney-chart',
 })
-export class ChartComponent<TSeries extends ISeries<TDataPoint>, TDataPoint extends ISeriesDataPoint> {
+export class ChartComponent<
+   TSeries extends ISeries<TDataPoint>,
+   TDataPoint extends ISeriesDataPoint
+> {
    @Input()
    public dataProvider!: IChartDataProvider<TSeries, TDataPoint>;
 

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/budget-series-data-point.class.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/budget-series-data-point.class.ts
@@ -11,12 +11,16 @@ export class BudgetSeriesDataPoint implements ISeriesDataPoint {
    public readonly amount: number;
    public readonly date: string;
 
-   constructor(public readonly transaction: ITransactionDto | null, remaining: number) {
+   constructor(
+      public readonly transaction: ITransactionDto | null,
+      remaining: number
+   ) {
       this.id = transaction?.id ?? -1;
       this.text = transaction?.description ?? DEFAULT_TEXT;
       this.value = remaining;
       this.amount = transaction?.amount ?? remaining;
       this.date = transaction?.date ?? '';
-      this.name = transaction !== null ? `Transaction ${transaction.id}` : DEFAULT_TEXT;
+      this.name =
+         transaction !== null ? `Transaction ${transaction.id}` : DEFAULT_TEXT;
    }
 }

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/budget-series-data-point.class.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/budget-series-data-point.class.ts
@@ -10,30 +10,13 @@ export class BudgetSeriesDataPoint implements ISeriesDataPoint {
    public readonly value: number;
    public readonly amount: number;
    public readonly date: string;
-   public readonly link: (string | number)[] | null;
 
-   constructor(transaction: ITransactionDto | null, remaining: number) {
+   constructor(public readonly transaction: ITransactionDto | null, remaining: number) {
       this.id = transaction?.id ?? -1;
       this.text = transaction?.description ?? DEFAULT_TEXT;
       this.value = remaining;
       this.amount = transaction?.amount ?? remaining;
       this.date = transaction?.date ?? '';
-
-      if (transaction !== null) {
-         this.name = `Transaction ${transaction.id}`;
-
-         if (transaction.parentId === null || transaction.id > 0) {
-            this.link = ['/transactions', 'edit', transaction.id];
-         } else {
-            this.link = [
-               '/transactions',
-               'edit-recurring',
-               transaction.parentId,
-            ];
-         }
-      } else {
-         this.name = DEFAULT_TEXT;
-         this.link = null;
-      }
+      this.name = transaction !== null ? `Transaction ${transaction.id}` : DEFAULT_TEXT;
    }
 }

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/budget-series.class.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/budget-series.class.ts
@@ -8,7 +8,10 @@ export class BudgetSeries implements ISeries<BudgetSeriesDataPoint> {
 
    private remaining: number;
 
-   constructor(public readonly budget: IBudgetDto, public readonly color: string) {
+   constructor(
+      public readonly budget: IBudgetDto,
+      public readonly color: string
+   ) {
       this.name = budget.name;
       this.series = [new BudgetSeriesDataPoint(null, budget.amount)];
       this.remaining = budget.amount;

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/budget-series.class.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/budget-series.class.ts
@@ -2,22 +2,20 @@ import { ITransactionDto, IBudgetDto } from '../api/dtos';
 import { ISeries } from '../interfaces/series.interface';
 import { BudgetSeriesDataPoint } from './budget-series-data-point.class';
 
-export class BudgetSeries implements ISeries {
+export class BudgetSeries implements ISeries<BudgetSeriesDataPoint> {
    public name: string; // Must be unique
    public series: BudgetSeriesDataPoint[];
+
    private remaining: number;
 
-   private id: number;
-
-   constructor(budget: IBudgetDto) {
+   constructor(public readonly budget: IBudgetDto, public readonly color: string) {
       this.name = budget.name;
       this.series = [new BudgetSeriesDataPoint(null, budget.amount)];
       this.remaining = budget.amount;
-      this.id = budget.id;
    }
 
    public addEntry(transaction: ITransactionDto) {
-      if (transaction.budgetIds.includes(this.id)) {
+      if (transaction.budgetIds.includes(this.budget.id)) {
          this.remaining -= transaction.amount;
       }
       this.series[this.series.length] = new BudgetSeriesDataPoint(

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/running-total-series-data-point.class.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/running-total-series-data-point.class.ts
@@ -11,7 +11,10 @@ export class RunningTotalSeriesDataPoint implements ISeriesDataPoint {
    public readonly amount: number;
    public readonly date: string;
 
-   constructor(public readonly runningTotal: IRunningTotalDto | null, initialTotal: number) {
+   constructor(
+      public readonly runningTotal: IRunningTotalDto | null,
+      initialTotal: number
+   ) {
       this.id = runningTotal?.id ?? 0;
       this.text = runningTotal?.text ?? DEFAULT_TEXT;
       this.value = runningTotal?.value ?? initialTotal;

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/running-total-series-data-point.class.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/running-total-series-data-point.class.ts
@@ -10,39 +10,13 @@ export class RunningTotalSeriesDataPoint implements ISeriesDataPoint {
    public readonly value: number;
    public readonly amount: number;
    public readonly date: string;
-   public readonly link: (string | number)[] | null;
 
-   constructor(runningTotal: IRunningTotalDto | null, initialTotal: number) {
+   constructor(public readonly runningTotal: IRunningTotalDto | null, initialTotal: number) {
       this.id = runningTotal?.id ?? 0;
       this.text = runningTotal?.text ?? DEFAULT_TEXT;
       this.value = runningTotal?.value ?? initialTotal;
       this.amount = runningTotal?.delta ?? 0;
       this.date = runningTotal?.date ?? '';
       this.name = runningTotal?.name ?? DEFAULT_TEXT;
-      this.link = null;
-
-      if (runningTotal !== null) {
-         if (this.amount > 0) {
-            if (runningTotal.parentId === null || this.id > 0) {
-               this.link = ['/incomes', 'edit', this.id];
-            } else {
-               this.link = [
-                  '/incomes',
-                  'edit-recurring',
-                  runningTotal.parentId,
-               ];
-            }
-         } else if (this.amount < 0) {
-            if (runningTotal.parentId === null || this.id > 0) {
-               this.link = ['/transactions', 'edit', this.id];
-            } else {
-               this.link = [
-                  '/transactions',
-                  'edit-recurring',
-                  runningTotal.parentId,
-               ];
-            }
-         }
-      }
    }
 }

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/running-total-series.class.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/running-total-series.class.ts
@@ -2,13 +2,13 @@ import { IRunningTotalDto } from '../api/dtos';
 import { ISeries } from '../interfaces/series.interface';
 import { RunningTotalSeriesDataPoint } from './running-total-series-data-point.class';
 
-export class RunningTotalSeries implements ISeries {
+export class RunningTotalSeries implements ISeries<RunningTotalSeriesDataPoint> {
    public name: string;
    public series: RunningTotalSeriesDataPoint[];
 
    private initialTotal: number;
 
-   constructor(initialTotal: number) {
+   constructor(initialTotal: number, public readonly color: string) {
       this.name = 'Running total';
       this.initialTotal = initialTotal;
       this.series = [new RunningTotalSeriesDataPoint(null, initialTotal)];

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/running-total-series.class.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/classes/running-total-series.class.ts
@@ -2,7 +2,9 @@ import { IRunningTotalDto } from '../api/dtos';
 import { ISeries } from '../interfaces/series.interface';
 import { RunningTotalSeriesDataPoint } from './running-total-series-data-point.class';
 
-export class RunningTotalSeries implements ISeries<RunningTotalSeriesDataPoint> {
+export class RunningTotalSeries
+   implements ISeries<RunningTotalSeriesDataPoint>
+{
    public name: string;
    public series: RunningTotalSeriesDataPoint[];
 

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/interfaces/index.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/interfaces/index.ts
@@ -1,4 +1,3 @@
 export * from './series.interface';
-export * from './series-item.interface';
 export * from './series-data-point.interface';
 export * from './session-model.interface';

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/interfaces/series-data-point.interface.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/interfaces/series-data-point.interface.ts
@@ -8,5 +8,4 @@ export interface ISeriesDataPoint {
    readonly value: number;
    readonly amount: number;
    readonly date: string;
-   readonly link: (string | number)[] | null;
 }

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/interfaces/series-item.interface.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/interfaces/series-item.interface.ts
@@ -1,3 +1,0 @@
-import { ISeriesDataPoint } from './series-data-point.interface';
-
-export type ISeriesItem = ISeriesDataPoint & { series: string };

--- a/MyMoney.Web/FrontEnd/libs/mymoney-common/src/interfaces/series.interface.ts
+++ b/MyMoney.Web/FrontEnd/libs/mymoney-common/src/interfaces/series.interface.ts
@@ -1,6 +1,7 @@
 import { ISeriesDataPoint } from './series-data-point.interface';
 
-export interface ISeries {
+export interface ISeries<TDataPoint extends ISeriesDataPoint> {
    name: string;
-   series: ISeriesDataPoint[];
+   color: string;
+   series: TDataPoint[];
 }


### PR DESCRIPTION
**Common**
- Removed `link` from `ISeriesDataPoint` as how links are done is different depending on front end
- Updated `ISeries` to allow genetic `TDataPoint` instead of constraining the type to `ISeriesDataPoint`. Also added `color` as a property as it is related to the series
- Removed `ISeriesItem` as it was unused
- Updated `RunningTotalSeries` to match the type changes and expose a `color` field
- Updated `BudgetSeries` to match the type changes and expose a `color` and `budget` field
- Moved `link` logic from `RunningTotalSeriesDataPoint` and `BudgetSeriesDataPoint` into their respective `IChartDataProivider`s

**Angular**
- Updated `IChartDataProvider` and `ChartComponent` to allow generic `ISeries` and `ISeriesDataPoint` type. Also removed rxjs `Observables`
- Updated `TransactionsChartDataProvider` and `RunningTotalChartDataProvider` to reflect the generic type changes, add the link logic and tidy up the series color logic
- Updated `HomeComponent` to reflect the chart data provider types