### PR TITLE
Added generic button support to charts in react

### DIFF
--- a/MyMoney.Web/FrontEnd/apps/mymoney-react/src/app/components/chart.tsx
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-react/src/app/components/chart.tsx
@@ -16,14 +16,6 @@ export default function Chart<
    TSeries extends ISeries<TDataPoint>,
    TDataPoint extends ISeriesDataPoint
 >({ dataProvider }: { dataProvider: IChartDataProvider<TSeries, TDataPoint> }) {
-   const title = dataProvider.subChartTitle ? (
-      <div>
-         {dataProvider.chartTitle} - {dataProvider.subChartTitle}
-      </div>
-   ) : (
-      <div>{dataProvider.chartTitle}</div>
-   );
-
    const lines = [];
 
    for (const series of dataProvider.data) {
@@ -54,30 +46,44 @@ export default function Chart<
       );
    }
 
+   const leftButtons = [];
+   for (const buttonOptions of dataProvider.leftButtons) {
+      leftButtons.push(
+         <button
+            className="btn btn-light btn-sm mr-1 material-icons"
+            type="button"
+            onClick={buttonOptions.onClick}
+            data-toggle="tooltip"
+            data-placement="bottom"
+            title={buttonOptions.tooltip}
+         >
+            {buttonOptions.icon}
+         </button>
+      );
+   }
+
+   const rightButtons = [];
+   for (const buttonOptions of dataProvider.rightButtons) {
+      rightButtons.push(
+         <button
+            className="btn btn-light btn-sm ml-1 material-icons"
+            type="button"
+            onClick={buttonOptions.onClick}
+            data-toggle="tooltip"
+            data-placement="bottom"
+            title={buttonOptions.tooltip}
+         >
+            {buttonOptions.icon}
+         </button>
+      );
+   }
+
    return (
       <>
-         <div className="container inline">
-            <button
-               className="btn btn-light btn-sm material-icons"
-               type="button"
-               onClick={dataProvider.previous}
-               data-toggle="tooltip"
-               data-placement="bottom"
-               title="Previous"
-            >
-               navigate_before
-            </button>
-            <span className="ml-auto">{title}</span>
-            <button
-               className="btn btn-light btn-sm ml-auto material-icons"
-               type="button"
-               onClick={dataProvider.next}
-               data-toggle="tooltip"
-               data-placement="bottom"
-               title="Next"
-            >
-               navigate_next
-            </button>
+         <div className="container inline mb-3">
+            {leftButtons}
+            <span className="ml-auto mr-auto">{dataProvider.chartTitle}</span>
+            {rightButtons}
          </div>
          <div
             style={{

--- a/MyMoney.Web/FrontEnd/apps/mymoney-react/src/app/components/remaining-budget-chart.tsx
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-react/src/app/components/remaining-budget-chart.tsx
@@ -67,29 +67,49 @@ function buildDataProvider(
 ): IChartDataProvider<BudgetSeries, BudgetSeriesDataPoint> {
    const date = monthAsDate(searchParameters);
    const monthString = date.toLocaleString('default', { month: 'long' });
-   const subChartTitle = `${monthString} ${date.getFullYear()}`;
+
+   function updateDate(isYear: boolean, increment: number) {
+      if (isYear) {
+         date.setFullYear(date.getFullYear() + increment);
+      } else {
+         date.setMonth(date.getMonth() + increment);
+      }
+
+      setMonth(date.getMonth(), date.getFullYear());
+   }
 
    return {
-      chartTitle: 'Transactions',
+      chartTitle: `Transactions - ${monthString} ${date.getFullYear()}`,
       yAxisLabel: 'Remaining in budget (£)',
-      subChartTitle,
       data,
-      next: () => {
-         date.setMonth(date.getMonth() + 1);
-
-         setMonth(date.getMonth(), date.getFullYear());
-      },
-      previous: () => {
-         date.setMonth(date.getMonth() - 1);
-
-         setMonth(date.getMonth(), date.getFullYear());
-      },
-      onClickDataPoint: (data: BudgetSeriesDataPoint) => {
-         navigate(`/transactions/edit?id=${data.id}`);
-      },
-      onClickSeries: (data: BudgetSeries) => {
-         navigate(`/budgets/edit?id=${data.budget.id}`);
-      },
+      leftButtons: [
+         {
+            icon: 'keyboard_double_arrow_left',
+            onClick: () => updateDate(true, -1),
+            tooltip: 'Previous year',
+         },
+         {
+            icon: 'navigate_before',
+            onClick: () => updateDate(false, -1),
+            tooltip: 'Previous month',
+         },
+      ],
+      rightButtons: [
+         {
+            icon: 'navigate_next',
+            onClick: () => updateDate(false, 1),
+            tooltip: 'Next month',
+         },
+         {
+            icon: 'keyboard_double_arrow_right',
+            onClick: () => updateDate(true, 1),
+            tooltip: 'Next year',
+         },
+      ],
+      onClickDataPoint: (data: BudgetSeriesDataPoint) =>
+         navigate(`/transactions/edit?id=${data.id}`),
+      onClickSeries: (data: BudgetSeries) =>
+         navigate(`/budgets/edit?id=${data.budget.id}`),
    };
 }
 

--- a/MyMoney.Web/FrontEnd/apps/mymoney-react/src/app/interfaces/chart-data-provider.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-react/src/app/interfaces/chart-data-provider.ts
@@ -1,4 +1,5 @@
 import { ISeries, ISeriesDataPoint } from '@mymoney-common/interfaces';
+import { IChartNavigationButton } from './chart-navigation-button';
 
 export interface IChartDataProvider<
    TSeries extends ISeries<TDataPoint>,
@@ -6,10 +7,9 @@ export interface IChartDataProvider<
 > {
    chartTitle: string;
    data: TSeries[];
-   subChartTitle: string;
    yAxisLabel: string;
    onClickDataPoint(data: TDataPoint): void;
    onClickSeries(data: TSeries): void;
-   next(): void;
-   previous(): void;
+   leftButtons: IChartNavigationButton[];
+   rightButtons: IChartNavigationButton[];
 }

--- a/MyMoney.Web/FrontEnd/apps/mymoney-react/src/app/interfaces/chart-navigation-button.ts
+++ b/MyMoney.Web/FrontEnd/apps/mymoney-react/src/app/interfaces/chart-navigation-button.ts
@@ -1,0 +1,6 @@
+
+export interface IChartNavigationButton {
+   onClick(): void;
+   icon: string;
+   tooltip: string;
+}


### PR DESCRIPTION
![image](https://github.com/RelativeForce/MyMoney/assets/24320350/8b362d6b-5dbe-497e-a0c1-501c0fcd179e)


- Added `IChartNavigationButton` for wrapping the data needed for a button at the top of the react chart
- Updated `IChartDataProvider` to allow the consumer to add any number of buttons to the right or left of the chart title
- Updated `RemainingBudgetChart` to add the ability to jump years and months