### PR TITLE
Fix publish for Nx monorepo

### DIFF
--- a/MyMoney.Web/.gitignore
+++ b/MyMoney.Web/.gitignore
@@ -136,7 +136,6 @@ publish/
 *.azurePubxml
 # TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
 *.publishproj
 
 # NuGet Packages

--- a/MyMoney.Web/FrontEnd/package.json
+++ b/MyMoney.Web/FrontEnd/package.json
@@ -3,8 +3,10 @@
    "version": "1.3.0",
    "license": "MIT",
    "scripts": {
-      "angular": "npx nx run mymoney-angular:serve",
-      "react": "npx nx run mymoney-react:serve",
+      "run-angular": "npx nx run mymoney-angular:serve",
+      "run-react": "npx nx run mymoney-react:serve",
+      "publish-angular": "npx nx run mymoney-angular:build",
+      "publish-react": "npx nx run mymoney-react:build",
       "format": "npx prettier --write ."
    },
    "private": true,

--- a/MyMoney.Web/MyMoney.Web.csproj
+++ b/MyMoney.Web/MyMoney.Web.csproj
@@ -6,9 +6,9 @@
     <TypeScriptToolsVersion>3.9</TypeScriptToolsVersion>
     <PublishWithAspNetCoreTargetManifest>false</PublishWithAspNetCoreTargetManifest>
     <IsPackable>false</IsPackable>
-    <FrontEndFramework>$(MyMoney_Front_End_FrameWork)</FrontEndFramework>
-    <SpaRoot Condition=" '$(FrontEndFramework)' == '' ">FrontEnd\Angular\</SpaRoot>
-    <SpaRoot Condition=" '$(FrontEndFramework)' != '' ">FrontEnd\$(FrontEndFramework)\</SpaRoot>
+    <FrontEndFramework Condition=" '$(MyMoney_Front_End_FrameWork)' != '' ">$(MyMoney_Front_End_FrameWork.toLower())</FrontEndFramework>
+    <FrontEndFramework Condition=" '$(MyMoney_Front_End_FrameWork)' == '' ">angular</FrontEndFramework>
+    <SpaRoot>FrontEnd\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
 
     <!-- Set this to true if you enable server-side prerendering -->
@@ -88,9 +88,10 @@
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
     <Copy SourceFiles="Resources\reset-password-email.html" DestinationFolder="$(PublishDir)\Resources" />
+    <RemoveDir Directories="$(SpaRoot)\dist" />
     <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build -- --prod" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build:ssr -- --prod" Condition=" '$(BuildServerSideRenderer)' == 'true' " />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run publish-$(FrontEndFramework)" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run publish-$(FrontEndFramework)-ssr" Condition=" '$(BuildServerSideRenderer)' == 'true' " />
 
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>

--- a/MyMoney.Web/Properties/PublishProfiles/PublishMyMoney.pubxml
+++ b/MyMoney.Web/Properties/PublishProfiles/PublishMyMoney.pubxml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <DeleteExistingFiles>true</DeleteExistingFiles>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>bin\Release\net6.0\publish\</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <_TargetId>Folder</_TargetId>
+    <SiteUrlToLaunchAfterPublish />
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <ProjectGuid>b47ea642-f3f3-444d-b642-26163505ea89</ProjectGuid>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/MyMoney.Web/Startup.cs
+++ b/MyMoney.Web/Startup.cs
@@ -130,7 +130,7 @@ namespace MyMoney.Web
          {
             if (env.IsDevelopment())
             {
-               //spa.UseProxyToSpaDevelopmentServer("http://localhost:4200");
+               spa.UseProxyToSpaDevelopmentServer("http://localhost:4200");
             }
          });
       }

--- a/MyMoney.Web/Startup.cs
+++ b/MyMoney.Web/Startup.cs
@@ -53,7 +53,7 @@ namespace MyMoney.Web
          // In production, the Angular files will be served from this directory
          services.AddSpaStaticFiles(configuration =>
          {
-            configuration.RootPath = $"FrontEnd/dist/apps/{FrontEndConstants.TargetFrontEndFramework}";
+            configuration.RootPath = $"FrontEnd/dist/apps/mymoney-{FrontEndConstants.TargetFrontEndFramework}".ToLowerInvariant();
          });
 
          services.AddAuthentication(x =>
@@ -130,7 +130,7 @@ namespace MyMoney.Web
          {
             if (env.IsDevelopment())
             {
-               spa.UseProxyToSpaDevelopmentServer("http://localhost:4200");
+               //spa.UseProxyToSpaDevelopmentServer("http://localhost:4200");
             }
          });
       }

--- a/README.md
+++ b/README.md
@@ -2,32 +2,5 @@
 
 Welcome to MyMoney, a simple money management website written by Joshua Eddy. MyMoney is built using ASP.Net 6.0 backend with an [Nx Monorepo](https://nx.dev/) front end that can toggled between with [Angular v16.0.3](https://angular.io) and [React v16.3.2](https://react.dev).
 
-## Issue process
-If you would like a new feature to be added please create a new feature issue.
-
-## Local production setup 
-Follow these steps to install and start a local instance of MyMoney.
-
-1. Download and install SQL Server Express [here](https://www.microsoft.com/en-gb/sql-server/sql-server-downloads)
-2. Go to the latest release of the app [here](https://github.com/RelativeForce/MyMoney/releases/latest)
-3. Download `MyMoney.exe`
-4. Move `MyMoney.exe` to the folder you would like app to run from
-5. Set up environment variables
-6. Run `MyMoney.exe`
-7. MyMoney will be available at http://localhost:5000 (https://localhost:5001 when SSL is enabled)
-
-## Environment variables
-| Name | Description | Default value | Optional |
-|---|---|---|---|
-| `MyMoney_Email_Smtp_Server_URL` | The url of the SMTP email server. |   | no |
-| `MyMoney_Email_Smtp_Server_Port` | The port number of the SMTP email server. |  | no |
-| `MyMoney_Email_Smtp_Server_SSL` | Whether or not to use SSL for requests to SMTP email server. | `true` | yes |
-| `MyMoney_Email_Address` | The email address of the account the site will use to send emails. |  | no |
-| `MyMoney_Email_Password` | The password of the account the site will use to send emails. |  | no |
-| `MyMoney_Database_Connection` | The connection string to the database. Defaults to the local SQL express server instance. | `Server=.\SQLEXPRESS; Initial Catalog=MyMoney; Trusted_Connection=True; MultipleActiveResultSets=true; Integrated Security=True` | yes |
-| `MyMoney_Database_Engine` | The database type of the connection. Only `MySQL` and `SQLServer` are supported. | `SQLServer` | yes |
-| `MyMoney_Local_Web_App_Path` | The folder path you would like to install the app into. | `.\Web` | yes |
-| `MyMoney_Front_End_Framework` | The framework to use for the front end. | `Angular` | yes |
-| `MyMoney_GitHub_URL` | The URL to the public GitHub repository. | `https://github.com/RelativeForce/MyMoney` | yes |
-| `MyMoney_Asset_File_Name` | The filename of the asset to download. Requires `{0}` Major version number, `{1}` Minor version number and `{2}` Hotfix number. | `MyMoney_win64_{0}-{1}-{2}.zip` | yes |
-| `MyMoney_Token_Secret` | The secret used for generating the user JWT tokens. You can generate one [here](https://www.grc.com/passwords.htm). | `dqSRHqsruH3U75hFSg1Y5LCOcON7G90iXGomYbaFuH4G10f2PIexSes3QlyidLC` | yes |
+## Wiki
+[Go to wiki](https://github.com/RelativeForce/MyMoney/wiki)


### PR DESCRIPTION
- Updated `package.json` to add `publish-angular` and `publish-react` scripts for publishing the front-end files for the published build
- Added `PublishMyMoney.pubxml` for publishing MyMoney.
- Updated `MyMoney.Web.csproj` to fix the publish steps for the new Nx Monorepo front-end
- Updated `Startup.cs` to fix the SPA target folder 
- Moved content from `README.md` to wiki